### PR TITLE
common/queues: make consumer groups read all messages

### DIFF
--- a/common/src/buttercup/common/queues.py
+++ b/common/src/buttercup/common/queues.py
@@ -169,7 +169,7 @@ class ReliableQueue(Generic[MsgType]):
         if self.group_name is not None:
             # Create consumer group if it doesn't exist
             try:
-                self.redis.xgroup_create(self.queue_name, self.group_name, mkstream=True)
+                self.redis.xgroup_create(self.queue_name, self.group_name, mkstream=True, id="0")
             except RedisError:
                 # Group may already exist
                 pass


### PR DESCRIPTION
To avoid losing messages sent to a queue before the necessary consumer groups are created, create them with `id=0`. In this way all messages are passed to the consumer group, not only those sent after the group has been created.

Closes #68 