### PR TITLE
Cleanup of group names for consumers

### DIFF
--- a/common/src/buttercup/common/queues.py
+++ b/common/src/buttercup/common/queues.py
@@ -36,12 +36,7 @@ class QueueNames(str, Enum):
 class GroupNames(str, Enum):
     BUILDER_BOT = "build_bot_consumers"
     ORCHESTRATOR = "orchestrator_group"
-    DOWNLOAD_TASKS = "orchestrator_download_tasks_group"
-    SCHEDULER_READY_TASKS = "scheduler_ready_tasks_group"
-    SCHEDULER_DELETE_TASK = "scheduler_delete_task_group"
-    SCHEDULER_BUILD_OUTPUT = "scheduler_build_output_group"
-    UNIQUE_VULNERABILITIES = "unique_vulnerabilities_group"
-    CONFIRMED_VULNERABILITIES = "confirmed_vulnerabilities_group"
+    PATCHER = "patcher_group"
 
 
 class HashNames(str, Enum):
@@ -268,19 +263,19 @@ class QueueFactory:
                 QueueNames.BUILD_OUTPUT,
                 BuildOutput,
                 BUILD_OUTPUT_TASK_TIMEOUT_MS,
-                [GroupNames.ORCHESTRATOR, GroupNames.SCHEDULER_BUILD_OUTPUT],
+                [GroupNames.ORCHESTRATOR],
             ),
             QueueNames.DOWNLOAD_TASKS: QueueConfig(
                 QueueNames.DOWNLOAD_TASKS,
                 TaskDownload,
                 DOWNLOAD_TASK_TIMEOUT_MS,
-                [GroupNames.DOWNLOAD_TASKS],
+                [GroupNames.ORCHESTRATOR],
             ),
             QueueNames.READY_TASKS: QueueConfig(
                 QueueNames.READY_TASKS,
                 TaskReady,
                 READY_TASK_TIMEOUT_MS,
-                [GroupNames.SCHEDULER_READY_TASKS],
+                [GroupNames.ORCHESTRATOR],
             ),
             QueueNames.CRASH: QueueConfig(
                 QueueNames.CRASH,
@@ -292,19 +287,19 @@ class QueueFactory:
                 QueueNames.UNIQUE_VULNERABILITIES,
                 Crash,
                 UNIQUE_VULNERABILITIES_TASK_TIMEOUT_MS,
-                [GroupNames.UNIQUE_VULNERABILITIES],
+                [GroupNames.ORCHESTRATOR],
             ),
             QueueNames.CONFIRMED_VULNERABILITIES: QueueConfig(
                 QueueNames.CONFIRMED_VULNERABILITIES,
                 ConfirmedVulnerability,
                 CONFIRMED_VULNERABILITIES_TASK_TIMEOUT_MS,
-                [GroupNames.CONFIRMED_VULNERABILITIES],
+                [GroupNames.PATCHER],
             ),
             QueueNames.DELETE_TASK: QueueConfig(
                 QueueNames.DELETE_TASK,
                 TaskDelete,
                 DELETE_TASK_TIMEOUT_MS,
-                [GroupNames.SCHEDULER_DELETE_TASK],
+                [GroupNames.ORCHESTRATOR],
             ),
             QueueNames.PATCHES: QueueConfig(
                 QueueNames.PATCHES,

--- a/orchestrator/src/buttercup/orchestrator/downloader/downloader.py
+++ b/orchestrator/src/buttercup/orchestrator/downloader/downloader.py
@@ -35,7 +35,7 @@ class Downloader:
         if self.redis is not None:
             logger.debug("Using Redis for task queue and registry")
             queue_factory = QueueFactory(self.redis)
-            self.task_queue = queue_factory.create(QueueNames.DOWNLOAD_TASKS, GroupNames.DOWNLOAD_TASKS)
+            self.task_queue = queue_factory.create(QueueNames.DOWNLOAD_TASKS, GroupNames.ORCHESTRATOR)
             self.ready_queue = queue_factory.create(QueueNames.READY_TASKS)
             self.registry = TaskRegistry(self.redis)
 

--- a/orchestrator/src/buttercup/orchestrator/scheduler/cancellation.py
+++ b/orchestrator/src/buttercup/orchestrator/scheduler/cancellation.py
@@ -31,7 +31,7 @@ class Cancellation:
     def __post_init__(self):
         """Initialize Redis connection, deletion queue and task registry."""
         self.delete_queue = QueueFactory(self.redis).create(
-            QueueNames.DELETE_TASK, GroupNames.SCHEDULER_DELETE_TASK, block_time=None
+            QueueNames.DELETE_TASK, GroupNames.ORCHESTRATOR, block_time=None
         )
         self.registry = TaskRegistry(self.redis)
 

--- a/orchestrator/src/buttercup/orchestrator/scheduler/scheduler.py
+++ b/orchestrator/src/buttercup/orchestrator/scheduler/scheduler.py
@@ -47,12 +47,10 @@ class Scheduler:
             # Input queues are non-blocking as we're already sleeping between iterations
             self.cancellation = Cancellation(redis=self.redis)
             self.vulnerabilities = Vulnerabilities(redis=self.redis, api_client=api_client)
-            self.ready_queue = queue_factory.create(
-                QueueNames.READY_TASKS, GroupNames.SCHEDULER_READY_TASKS, block_time=None
-            )
+            self.ready_queue = queue_factory.create(QueueNames.READY_TASKS, GroupNames.ORCHESTRATOR, block_time=None)
             self.build_requests_queue = queue_factory.create(QueueNames.BUILD, block_time=None)
             self.build_output_queue = queue_factory.create(
-                QueueNames.BUILD_OUTPUT, GroupNames.SCHEDULER_BUILD_OUTPUT, block_time=None
+                QueueNames.BUILD_OUTPUT, GroupNames.ORCHESTRATOR, block_time=None
             )
             self.harness_map = HarnessWeights(self.redis)
             self.build_map = BuildMap(self.redis)

--- a/orchestrator/src/buttercup/orchestrator/scheduler/vulnerabilities.py
+++ b/orchestrator/src/buttercup/orchestrator/scheduler/vulnerabilities.py
@@ -35,7 +35,7 @@ class Vulnerabilities:
         queue_factory = QueueFactory(self.redis)
         self.crash_queue = queue_factory.create(QueueNames.CRASH, GroupNames.ORCHESTRATOR, block_time=None)
         self.unique_vulnerabilities_queue = queue_factory.create(
-            QueueNames.UNIQUE_VULNERABILITIES, GroupNames.UNIQUE_VULNERABILITIES, block_time=None
+            QueueNames.UNIQUE_VULNERABILITIES, GroupNames.ORCHESTRATOR, block_time=None
         )
         self.confirmed_vulnerabilities_queue = queue_factory.create(
             QueueNames.CONFIRMED_VULNERABILITIES, block_time=None

--- a/patcher/src/buttercup/patcher/patcher.py
+++ b/patcher/src/buttercup/patcher/patcher.py
@@ -35,9 +35,7 @@ class Patcher:
     def __post_init__(self):
         if self.redis is not None:
             queue_factory = QueueFactory(self.redis)
-            self.vulnerability_queue = queue_factory.create(
-                QueueNames.CONFIRMED_VULNERABILITIES, GroupNames.CONFIRMED_VULNERABILITIES
-            )
+            self.vulnerability_queue = queue_factory.create(QueueNames.CONFIRMED_VULNERABILITIES, GroupNames.PATCHER)
             self.patches_queue = queue_factory.create(QueueNames.PATCHES)
 
     def _chain_call(


### PR DESCRIPTION
We only really need distinct consumer group names if there are multiple consumers. Most consumers are still the orchestrator components so I've simplified things a bit and removed group names that weren't needed.