### PR TITLE
Fix an incorrect status check

### DIFF
--- a/orchestrator/src/buttercup/orchestrator/scheduler/submissions.py
+++ b/orchestrator/src/buttercup/orchestrator/scheduler/submissions.py
@@ -1192,7 +1192,7 @@ class Submissions:
         elif status == SubmissionResult.ERRORED:
             _increase_submission_attempts(e)
             log_entry(e, i=i, msg=f"Patch submission errored, will try again. Attempts={e.patch_submission_attempts}")
-        elif status == SubmissionResult.FAILED or SubmissionResult.INCONCLUSIVE:
+        elif status == SubmissionResult.FAILED or status == SubmissionResult.INCONCLUSIVE:
             # Bad patch (or undecided state), move on to next
             _advance_patch_idx(e)
             log_entry(


### PR DESCRIPTION
This would not have any effect in practice as we always get `ACCEPTED` from the API. But, in theory there might be a super tiny edge case that could trigger this and that would cause us to start working on the next patch instead of keeping the one we currently have.