### PR TITLE
Allow for non AIxCC-related deployment

### DIFF
--- a/deployment/env.template
+++ b/deployment/env.template
@@ -1,6 +1,6 @@
 # Reference a values file for kubernetes deployment. This should be a template
 # file, filled by crs-architecture.sh with the correct variables.
-# See values-minikube.template, values-aks.template, values-prod.template
+# See values-upstream-minikube.template, values-minikube.template, values-aks.template, values-prod.template
 export BUTTERCUP_K8S_VALUES_TEMPLATE="k8s/values-minikube.template"
 
 # Namespace used to install the whole CRS in.
@@ -82,3 +82,8 @@ export DOCKER_PAT="<your-docker-pat>"
 # Optionally modify the container image org part used for accessing challenges
 # containers. Use aixcc-afc by default, but modify this to use upstream oss-fuzz.
 # export FUZZ_TOOLING_CONTAINER_ORG="gcr.io/oss-fuzz"
+
+# Docker build arguments, useful for local deployment
+# By default these points to the aixcc-finals images
+# export FUZZER_BASE_IMAGE="gcr.io/oss-fuzz-base/base-runner"
+# export CSCOPE_IMAGE="ghcr.io/trailofbits/buttercup-cscope:main"

--- a/deployment/k8s/charts/image-preloader/templates/job.yaml
+++ b/deployment/k8s/charts/image-preloader/templates/job.yaml
@@ -36,13 +36,15 @@ spec:
             echo "Docker daemon ready, starting to pull images..."
             
             # Pull all configured images
-            {{- range .Values.imagesToPull }}
-            echo "Pulling {{ . }}..."
-            docker pull {{ . }}
+            {{- range $version := .Values.versions }}
+            {{- range $image := $.Values.baseImages }}
+            echo "Pulling {{ $image }}:{{ $version }}..."
+            docker pull {{ $image }}:{{ $version }}
             if [ $? -ne 0 ]; then
-              echo "Failed to pull {{ . }}"
+              echo "Failed to pull {{ $image }}:{{ $version }}"
               exit 1
             fi
+            {{- end }}
             {{- end }}
             
             echo "All images pulled successfully. Running system prune..."

--- a/deployment/k8s/charts/image-preloader/values.yaml
+++ b/deployment/k8s/charts/image-preloader/values.yaml
@@ -14,44 +14,24 @@ resources:
     memory: 512Mi
 
 # List of images to pull
-imagesToPull:
-  - ghcr.io/aixcc-finals/base-runner:v1.3.0
-  - ghcr.io/aixcc-finals/base-builder:v1.3.0
-  - ghcr.io/aixcc-finals/base-image:v1.3.0
-  - ghcr.io/aixcc-finals/base-clang:v1.3.0
-  - ghcr.io/aixcc-finals/base-runner-debug:v1.3.0
-  - ghcr.io/aixcc-finals/base-builder-jvm:v1.3.0
-  - ghcr.io/aixcc-finals/base-builder-ruby:v1.3.0
-  - ghcr.io/aixcc-finals/base-builder-go:v1.3.0
-  - ghcr.io/aixcc-finals/base-builder-python:v1.3.0
-  - ghcr.io/aixcc-finals/base-builder-rust:v1.3.0
-  - ghcr.io/aixcc-finals/base-runner:v1.2.1
-  - ghcr.io/aixcc-finals/base-builder:v1.2.1
-  - ghcr.io/aixcc-finals/base-image:v1.2.1
-  - ghcr.io/aixcc-finals/base-clang:v1.2.1
-  - ghcr.io/aixcc-finals/base-runner-debug:v1.2.1
-  - ghcr.io/aixcc-finals/base-builder-jvm:v1.2.1
-  - ghcr.io/aixcc-finals/base-builder-ruby:v1.2.1
-  - ghcr.io/aixcc-finals/base-builder-go:v1.2.1
-  - ghcr.io/aixcc-finals/base-builder-python:v1.2.1
-  - ghcr.io/aixcc-finals/base-builder-rust:v1.2.1
-  - ghcr.io/aixcc-finals/base-runner:v1.1.0
-  - ghcr.io/aixcc-finals/base-builder:v1.1.0
-  - ghcr.io/aixcc-finals/base-image:v1.1.0
-  - ghcr.io/aixcc-finals/base-clang:v1.1.0
-  - ghcr.io/aixcc-finals/base-runner-debug:v1.1.0
-  - ghcr.io/aixcc-finals/base-builder-jvm:v1.1.0
-  - ghcr.io/aixcc-finals/base-builder-ruby:v1.1.0
-  - ghcr.io/aixcc-finals/base-builder-go:v1.1.0
-  - ghcr.io/aixcc-finals/base-builder-python:v1.1.0
-  - ghcr.io/aixcc-finals/base-builder-rust:v1.1.0
-  - ghcr.io/aixcc-finals/base-runner:v1.0.0
-  - ghcr.io/aixcc-finals/base-builder:v1.0.0
-  - ghcr.io/aixcc-finals/base-image:v1.0.0
-  - ghcr.io/aixcc-finals/base-clang:v1.0.0
-  - ghcr.io/aixcc-finals/base-runner-debug:v1.0.0
-  - ghcr.io/aixcc-finals/base-builder-jvm:v1.0.0
-  - ghcr.io/aixcc-finals/base-builder-ruby:v1.0.0
-  - ghcr.io/aixcc-finals/base-builder-go:v1.0.0
-  - ghcr.io/aixcc-finals/base-builder-python:v1.0.0
-  - ghcr.io/aixcc-finals/base-builder-rust:v1.0.0
+# Define base image names and versions
+baseImages:
+  - ghcr.io/aixcc-finals/base-runner
+  - ghcr.io/aixcc-finals/base-builder
+  - ghcr.io/aixcc-finals/base-image
+  - ghcr.io/aixcc-finals/base-clang
+  - ghcr.io/aixcc-finals/base-runner-debug
+  - ghcr.io/aixcc-finals/base-builder-jvm
+  - ghcr.io/aixcc-finals/base-builder-ruby
+  - ghcr.io/aixcc-finals/base-builder-go
+  - ghcr.io/aixcc-finals/base-builder-python
+  - ghcr.io/aixcc-finals/base-builder-rust
+
+versions:
+  - v1.3.0
+  - v1.2.1
+  - v1.1.0
+  - v1.0.0
+
+# List of images to pull (will be generated dynamically in template)
+imagesToPull: []

--- a/deployment/k8s/values-upstream-minikube.template
+++ b/deployment/k8s/values-upstream-minikube.template
@@ -1,0 +1,85 @@
+global:
+  environment: "minikube"
+  ossFuzzContainerOrg: "${FUZZ_TOOLING_CONTAINER_ORG}"
+  orchestratorImage:
+    repository: localhost/orchestrator
+    tag: "latest"
+    pullPolicy: Never
+  fuzzerImage:
+    repository: localhost/fuzzer
+    tag: "latest"
+    pullPolicy: Never
+  seedGenImage:
+    repository: localhost/seed-gen
+    tag: "latest"
+    pullPolicy: Never
+  patcherImage:
+    repository: localhost/patcher
+    tag: "latest"
+    pullPolicy: Never
+  programModelImage:
+    repository: localhost/program-model
+    tag: "latest"
+    pullPolicy: Never
+  competitionApiImage:
+    repository: ghcr.io/trailofbits/buttercup/competition-test-api
+    tag: v1.4-rc1
+    pullPolicy: Always
+    pullSecrets: ["ghcr-auth"]
+
+  langfuse:
+    enabled: ${LANGFUSE_ENABLED}
+    host: "${LANGFUSE_HOST}"
+    publicKey: "${LANGFUSE_PUBLIC_KEY}"
+    secretKey: "${LANGFUSE_SECRET_KEY}"
+
+  crs:
+    api_key_id: ${CRS_KEY_ID}
+    api_key_token: ${CRS_KEY_TOKEN}
+    api_key_token_hash: "${CRS_KEY_TOKEN_HASH}"
+    api_url: "${CRS_URL}"
+    hostname: "${CRS_API_HOSTNAME}"
+    competition_api_key_id: ${COMPETITION_API_KEY_ID}
+    competition_api_key_token: ${COMPETITION_API_KEY_TOKEN}
+    competition_api_url: "${COMPETITION_API_URL}"
+
+  otel:
+    endpoint: "${OTEL_ENDPOINT}"
+    token: "${OTEL_TOKEN}"
+    protocol: "${OTEL_PROTOCOL}"
+
+redis:
+  master:
+    persistence:
+      enabled: false
+
+litellm:
+  masterKey: "${LITELLM_MASTER_KEY}"
+  azure:
+    apiBase: "${AZURE_API_BASE}"
+    apiKey: "${AZURE_API_KEY}"
+  openai:
+    apiKey: "${OPENAI_API_KEY}"
+  anthropic:
+    apiKey: "${ANTHROPIC_API_KEY}"
+
+competition-api:
+  enabled: ${COMPETITION_API_ENABLED}
+
+mock-competition-api:
+  enabled: ${MOCK_COMPETITION_API_ENABLED}
+
+image-preloader:
+  baseImages:
+    - gcr.io/oss-fuzz/base-runner
+    - gcr.io/oss-fuzz/base-builder
+    - gcr.io/oss-fuzz/base-image
+    - gcr.io/oss-fuzz/base-clang
+    - gcr.io/oss-fuzz/base-runner-debug
+    - gcr.io/oss-fuzz-base/base-builder-jvm
+    - gcr.io/oss-fuzz-base/base-builder-ruby
+    - gcr.io/oss-fuzz-base/base-builder-go
+    - gcr.io/oss-fuzz-base/base-builder-python
+    - gcr.io/oss-fuzz-base/base-builder-rust
+  versions:
+    - latest

--- a/fuzzer/dockerfiles/runner_image.Dockerfile
+++ b/fuzzer/dockerfiles/runner_image.Dockerfile
@@ -1,20 +1,21 @@
-
-
 ARG BASE_IMAGE=ghcr.io/aixcc-finals/base-runner:v1.3.0
 
-FROM $BASE_IMAGE AS runner-base
-RUN apt-get update
-# TODO(Ian): maybe we should have a different base image for the builder
-RUN curl -fsSL https://get.docker.com | sh
-
-FROM $BASE_IMAGE AS builder
+FROM $BASE_IMAGE AS base-image
 
 COPY --from=ghcr.io/astral-sh/uv:0.5.20 /uv /uvx /bin/
 
 ENV UV_LINK_MODE=copy
 ENV UV_COMPILE_BYTECODE=1
-ENV UV_PYTHON_DOWNLOADS=never
-ENV UV_PYTHON=/usr/local/bin/python3.10
+ENV UV_PYTHON_DOWNLOADS=manual
+
+RUN uv python install python3.10
+
+FROM base-image AS runner-base
+RUN apt-get update
+# TODO(Ian): maybe we should have a different base image for the builder
+RUN curl -fsSL https://get.docker.com | sh
+
+FROM base-image AS builder
 
 WORKDIR /fuzzer
 

--- a/orchestrator/scripts/task_upstream_libpng.sh
+++ b/orchestrator/scripts/task_upstream_libpng.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+curl -X 'POST' 'http://127.0.0.1:31323/webhook/trigger_task' -H 'Content-Type: application/json' -d '{
+    "challenge_repo_url": "https://github.com/pnggroup/libpng",
+    "challenge_repo_head_ref": "libpng16",
+    "fuzz_tooling_url": "https://github.com/google/oss-fuzz",
+    "fuzz_tooling_ref": "master",
+    "fuzz_tooling_project_name": "libpng",
+    "duration": 1800
+}'

--- a/patcher/Dockerfile
+++ b/patcher/Dockerfile
@@ -1,4 +1,7 @@
 ARG BASE_IMAGE=ubuntu:24.04
+ARG CSCOPE_IMAGE=ghcr.io/aixcc-finals/buttercup-cscope:main
+
+FROM $CSCOPE_IMAGE AS cscope-image
 
 FROM $BASE_IMAGE AS python_base
 ARG PYTHON_VERSION=3.12
@@ -48,7 +51,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 
 FROM runtime-base AS cscope-builder
-COPY --from=ghcr.io/aixcc-finals/buttercup-cscope:main /cscope /cscope
+COPY --from=cscope-image /cscope /cscope
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y autoconf gcc make bison flex libncurses-dev
 RUN cd /cscope && autoreconf -i -s && ./configure && make && make install
 

--- a/program-model/Dockerfile
+++ b/program-model/Dockerfile
@@ -1,4 +1,7 @@
 ARG BASE_IMAGE=ubuntu:24.04@sha256:f8b860e4f9036f2694571770da292642eebcc4c2ea0c70a1a9244c2a1d436cd9
+ARG CSCOPE_IMAGE=ghcr.io/aixcc-finals/buttercup-cscope:main
+
+FROM $CSCOPE_IMAGE AS cscope-image
 
 FROM $BASE_IMAGE AS base
 RUN apt-get update && apt-get install -y software-properties-common
@@ -32,7 +35,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-editable
 
 FROM base AS cscope-builder
-COPY --from=ghcr.io/aixcc-finals/buttercup-cscope:main /cscope /cscope
+COPY --from=cscope-image /cscope /cscope
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y autoconf gcc make bison flex libncurses-dev
 RUN cd /cscope && autoreconf -i -s && ./configure && make && make install
 

--- a/seed-gen/Dockerfile
+++ b/seed-gen/Dockerfile
@@ -1,4 +1,7 @@
 ARG BASE_IMAGE=ubuntu:24.04
+ARG CSCOPE_IMAGE=ghcr.io/aixcc-finals/buttercup-cscope:main
+
+FROM $CSCOPE_IMAGE AS cscope-image
 
 FROM $BASE_IMAGE AS python_base
 ARG PYTHON_VERSION=3.12
@@ -42,7 +45,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     cd seed-gen && uv sync --frozen --no-editable
 
 FROM runtime-base AS cscope-builder
-COPY --from=ghcr.io/aixcc-finals/buttercup-cscope:main /cscope /cscope
+COPY --from=cscope-image /cscope /cscope
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf gcc make bison flex libncurses-dev
 RUN cd /cscope && autoreconf -i -s && ./configure && make && make install
 


### PR DESCRIPTION
A few things I had to do to make this work:
- push https://github.com/orgs/trailofbits/packages/container/package/buttercup-cscope 
- copy the competition-test-api from aixcc-finals into https://github.com/orgs/trailofbits/packages/container/package/buttercup%2Fcompetition-test-api

Unfortunately, although the competition-test-api works for submitting tasks to the CRS, the whole workflow won't work well because it is going to reject any PoV when found by the CRS (it expects some aixcc-specific flags in oss-fuzz that are ofc not present in the upstream version).