### PR TITLE
Bump dependencies in seed-gen and add test

### DIFF
--- a/seed-gen/pyproject.toml
+++ b/seed-gen/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
     "program-model",
     "numpy ~= 2.2.3",
     "rapidfuzz ~= 3.12.2",
-    "langgraph ~= 0.3.20",
-    "pydantic ~= 2.10.6",
+    "langgraph ~= 0.5.2",
+    "langchain ~= 0.3.20",
     "python-dotenv>=1.0.1",
 ]
 requires-python = ">=3.12,<3.13"

--- a/seed-gen/test/test_vuln_discovery_delta.py
+++ b/seed-gen/test/test_vuln_discovery_delta.py
@@ -1,0 +1,361 @@
+"""Tests for VulnDiscoveryDeltaTask"""
+
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.messages.tool import ToolCall
+from redis import Redis
+
+from buttercup.common.challenge_task import ChallengeTask
+from buttercup.common.project_yaml import Language, ProjectYaml
+from buttercup.common.reproduce_multiple import ReproduceMultiple
+from buttercup.common.task_meta import TaskMeta
+from buttercup.program_model.codequery import CodeQueryPersistent
+from buttercup.seed_gen.find_harness import HarnessInfo
+from buttercup.seed_gen.vuln_discovery_delta import VulnDiscoveryDeltaTask
+
+
+@pytest.fixture
+def mock_llm():
+    """Create a mock LLM"""
+    llm = MagicMock(spec=BaseChatModel)
+    llm.model_name = "claude-4-sonnet"
+    llm.bind_tools.return_value = llm
+    llm.with_fallbacks.return_value = llm
+    return llm
+
+
+@pytest.fixture
+def mock_challenge_task(tmp_path):
+    """Create a mock challenge task."""
+    task_dir = tmp_path / "test-challenge"
+    task_dir.mkdir(parents=True)
+
+    # Create required directories
+    (task_dir / "src").mkdir()
+    (task_dir / "fuzz-tooling").mkdir()
+    (task_dir / "diff").mkdir()
+
+    # Create a mock project.yaml
+    project_yaml_path = task_dir / "fuzz-tooling" / "projects" / "test_project" / "project.yaml"
+    project_yaml_path.parent.mkdir(parents=True)
+    project_yaml_path.write_text("""name: test_project
+language: c
+""")
+
+    # Create a mock helper.py in infra/infra/helper.py
+    helper_path = task_dir / "fuzz-tooling" / "infra" / "infra" / "helper.py"
+    helper_path.parent.mkdir(parents=True)
+    helper_path.write_text("import sys; sys.exit(0)")
+
+    # Create task metadata
+    TaskMeta(
+        project_name="test_project",
+        focus="test-source",
+        task_id="test-task-id",
+        metadata={"task_id": "test-task-id", "round_id": "testing", "team_id": "tob"},
+    ).save(task_dir)
+
+    # Create a mock diff file
+    diff_file = task_dir / "diff" / "test.diff"
+    diff_file.write_text("""--- a/src/test.c
++++ b/src/test.c
+@@ -10,6 +10,7 @@ int vulnerable_function(char* input) {
+    char buffer[100];
+    strcpy(buffer, input);  // Potential buffer overflow
++    printf(\"Processed: %s\", buffer);
+    return 0;
+}
+""")
+
+    # Create a mock source file
+    source_file = task_dir / "src" / "test.c"
+    source_file.write_text("""#include <string.h>
+#include <stdio.h>
+
+int vulnerable_function(char* input) {
+    char buffer[100];
+    strcpy(buffer, input);  // Potential buffer overflow
+    printf(\"Processed: %s\", buffer);
+    return 0;
+}
+
+int main() {
+    vulnerable_function(\"test\");
+    return 0;
+}
+""")
+
+    challenge_task = ChallengeTask(read_only_task_dir=task_dir)
+    challenge_task.is_delta_mode = Mock(return_value=True)
+    challenge_task.get_diffs = Mock(return_value=[diff_file])
+
+    return challenge_task
+
+
+@pytest.fixture
+def mock_codequery():
+    """Create a mock CodeQueryPersistent."""
+    codequery = MagicMock(spec=CodeQueryPersistent)
+    return codequery
+
+
+@pytest.fixture
+def mock_project_yaml():
+    """Create a mock ProjectYaml."""
+    project_yaml = MagicMock(spec=ProjectYaml)
+    project_yaml.unified_language = Language.C
+    return project_yaml
+
+
+@pytest.fixture
+def mock_redis():
+    """Create a mock Redis instance."""
+    return MagicMock(spec=Redis)
+
+
+@pytest.fixture
+def mock_reproduce_multiple():
+    """Create a mock ReproduceMultiple."""
+    reproduce_multiple = MagicMock(spec=ReproduceMultiple)
+
+    @contextmanager
+    def mock_context():
+        yield reproduce_multiple
+
+    reproduce_multiple.open = mock_context
+    reproduce_multiple.get_crashes = Mock(return_value=[])
+
+    return reproduce_multiple
+
+
+@pytest.fixture
+def vuln_discovery_task(
+    mock_challenge_task,
+    mock_codequery,
+    mock_project_yaml,
+    mock_redis,
+    mock_reproduce_multiple,
+    mock_llm,
+):
+    """Create a VulnDiscoveryDeltaTask instance with mocked dependencies."""
+    with (
+        patch("buttercup.seed_gen.task.Task.get_llm", return_value=mock_llm),
+    ):
+        task = VulnDiscoveryDeltaTask(
+            package_name="test_package",
+            harness_name="test_harness",
+            challenge_task=mock_challenge_task,
+            codequery=mock_codequery,
+            project_yaml=mock_project_yaml,
+            redis=mock_redis,
+            reproduce_multiple=mock_reproduce_multiple,
+            sarifs=[],
+            crash_submit=None,
+        )
+
+        return task
+
+
+@pytest.fixture
+def mock_harness_info():
+    """Create mock harness info."""
+    return HarnessInfo(
+        file_path=Path("/src/test_harness.c"),
+        code="""#include <stdint.h>
+#include <stdlib.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size < 1) return 0;
+
+    char* input = malloc(size + 1);
+    memcpy(input, data, size);
+    input[size] = '\\0';
+
+    vulnerable_function(input);
+    free(input);
+    return 0;
+}
+""",
+        harness_name="test_harness",
+    )
+
+
+def mock_sandbox_exec_funcs(functions: str, output_dir: Path):
+    """Mock sandbox that writes PoV files to the output directory."""
+    # Check for strings that should be in python code
+    assert "def " in functions
+    assert "return" in functions
+
+    pov1_path = output_dir / "gen_test_case_1.seed"
+    pov1_path.write_bytes(b"mock_pov_data_1")
+
+    pov2_path = output_dir / "gen_test_case_2.seed"
+    pov2_path.write_bytes(b"mock_pov_data_2")
+
+
+def test_do_task_no_valid_povs(
+    vuln_discovery_task,
+    mock_llm,
+    mock_harness_info,
+    tmp_path,
+):
+    """Test successful execution of do_task method with no valid PoVs found"""
+    out_dir = tmp_path / "out"
+    current_dir = tmp_path / "current"
+    out_dir.mkdir()
+    current_dir.mkdir()
+
+    vuln_discovery_task.get_harness_source = Mock(return_value=mock_harness_info)
+
+    with (
+        patch("buttercup.common.llm.get_langfuse_callbacks", return_value=[]),
+        patch("opentelemetry.trace.get_tracer") as mock_tracer,
+        patch("buttercup.seed_gen.vuln_base_task.set_crs_attributes") as mock_set_attrs,
+        patch("buttercup.seed_gen.vuln_base_task.sandbox_exec_funcs") as mock_sandbox_exec,
+    ):
+        # Mock the tracer span
+        mock_span = MagicMock()
+        mock_tracer.return_value.start_as_current_span.return_value.__enter__.return_value = (
+            mock_span
+        )
+        mock_sandbox_exec.side_effect = mock_sandbox_exec_funcs
+
+        # Mock LLM responses for the workflow
+        context_messages = [
+            # Context gathering - first iteration
+            AIMessage(
+                content="I'll gather context about the vulnerability",
+                tool_calls=[
+                    ToolCall(
+                        id="context_call_1",
+                        name="get_function_definition",
+                        args={"function_name": "vulnerable_function"},
+                    )
+                ],
+            ),
+            AIMessage(
+                content="I need more context",
+                tool_calls=[
+                    ToolCall(
+                        id="context_call_2",
+                        name="get_type_definition",
+                        args={"type_name": "buffer_t"},
+                    )
+                ],
+            ),
+            AIMessage(
+                content="I need more context",
+                tool_calls=[
+                    ToolCall(
+                        id="context_call_3",
+                        name="cat",
+                        args={"file_path": "/src/test.c"},
+                    )
+                ],
+            ),
+            AIMessage(
+                content="I need more context",
+                tool_calls=[
+                    ToolCall(
+                        id="context_call_4",
+                        name="get_callers",
+                        args={"function_name": "vulnerable_function", "file_path": "/src/test.c"},
+                    )
+                ],
+            ),
+            AIMessage(content="Making no tool calls for this context iteration"),
+            AIMessage(
+                content="Doing an empty batch tool call",
+                tool_calls=[
+                    ToolCall(
+                        id="context_call_5",
+                        name="batch_tool",
+                        args={"tool_calls": {"calls": []}},
+                    )
+                ],
+            ),
+        ]
+
+        vuln_messages = [
+            # Bug analysis
+            AIMessage(content="This is a buffer overflow vulnerability in the strcpy function"),
+            # PoV writing
+            AIMessage(
+                content=(
+                    "Here are the test functions:\n\n```python\ndef gen_test_case_1() -> bytes:\n"
+                    '    return b"A" * 200  # Buffer overflow test case\n'
+                    "def gen_test_case_2() -> bytes:\n"
+                    '    return b"B" * 300  # Another buffer overflow test case\n```'
+                ),
+            ),
+        ]
+        # this works because there is 1 mock_llm instance for the test
+        mock_llm.invoke.side_effect = (
+            context_messages + vuln_messages * vuln_discovery_task.MAX_POV_ITERATIONS
+        )
+
+        # Mock codequery for tools
+        vuln_discovery_task.codequery.get_functions = Mock(
+            return_value=[
+                MagicMock(
+                    name="vulnerable_function",
+                    file_path=Path("/src/test.c"),
+                    bodies=[
+                        MagicMock(
+                            body="int vulnerable_function(char* input) { /* function body */ }"
+                        )
+                    ],
+                )
+            ]
+        )
+        vuln_discovery_task.codequery.get_types = Mock(
+            return_value=[
+                MagicMock(
+                    file_path=Path("/src/test.c"),
+                    definition="typedef struct { int size; char* data; } buffer_t;",
+                )
+            ]
+        )
+        vuln_discovery_task.codequery.get_callers = Mock(
+            return_value=[
+                MagicMock(
+                    file_path=Path("/src/main.c"),
+                    bodies=[
+                        MagicMock(body='int main() { vulnerable_function("test"); return 0; }')
+                    ],
+                    name="main",
+                )
+            ]
+        )
+
+        # Mock challenge_task.exec_docker_cmd for cat tool
+        vuln_discovery_task.challenge_task.exec_docker_cmd = Mock(
+            return_value=MagicMock(
+                success=True, output=b"int vulnerable_function(char* input) { /* function body */ }"
+            )
+        )
+
+        vuln_discovery_task.do_task(out_dir, current_dir)
+
+        mock_tracer.assert_called_once_with("buttercup.seed_gen.vuln_base_task")
+        mock_set_attrs.assert_called_once()
+
+        mock_sandbox_exec.assert_called()
+
+        for i in range(vuln_discovery_task.MAX_POV_ITERATIONS):
+            iter_pov_files = list(out_dir.glob(f"iter{i}_*.seed"))
+            assert (
+                len(iter_pov_files) == 2
+            ), f"Expected 2 PoV files for iter{i}, found {len(iter_pov_files)}: {iter_pov_files}"
+
+            # Check the content of the PoV files
+            iter_pov1_file = next(f for f in iter_pov_files if "gen_test_case_1" in f.name)
+            iter_pov2_file = next(f for f in iter_pov_files if "gen_test_case_2" in f.name)
+
+            assert iter_pov1_file.read_bytes() == b"mock_pov_data_1"
+            assert iter_pov2_file.read_bytes() == b"mock_pov_data_2"

--- a/seed-gen/uv.lock
+++ b/seed-gen/uv.lock
@@ -3,14 +3,6 @@ revision = 2
 requires-python = "==3.12.*"
 
 [[package]]
-name = "aenum"
-version = "3.1.16"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/52/6ad8f63ec8da1bf40f96996d25d5b650fdd38f5975f8c813732c47388f18/aenum-3.1.16-py3-none-any.whl", hash = "sha256:9035092855a98e41b66e3d0998bd7b96280e85ceb3a04cc035636138a1943eaf", size = 165627, upload-time = "2025-04-25T03:17:58.89Z" },
-]
-
-[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -105,15 +97,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
-]
-
-[[package]]
-name = "async-timeout"
-version = "4.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/d6/21b30a550dafea84b1b8eee21b5e23fa16d010ae006011221f33dcd8d7f8/async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f", size = 8345, upload-time = "2023-08-10T16:35:56.907Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028", size = 5721, upload-time = "2023-08-10T16:35:55.203Z" },
 ]
 
 [[package]]
@@ -264,6 +247,9 @@ dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.9.2" },
+    { name = "types-pyyaml" },
+    { name = "types-redis" },
+    { name = "types-requests" },
 ]
 
 [[package]]
@@ -380,22 +366,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190, upload-time = "2025-06-05T16:36:48.59Z" },
     { url = "https://files.pythonhosted.org/packages/f5/e1/25297f70717abe8104c20ecf7af0a5b82d2f5a980eb1ac79f65654799f9f/greenlet-3.2.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:93d48533fade144203816783373f27a97e4193177ebaaf0fc396db19e5d61163", size = 1149055, upload-time = "2025-06-05T16:12:40.457Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8f/8f9e56c5e82eb2c26e8cde787962e66494312dc8cb261c460e1f3a9c88bc/greenlet-3.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:7454d37c740bb27bdeddfc3f358f26956a07d5220818ceb467a483197d84f849", size = 297817, upload-time = "2025-06-05T16:29:49.244Z" },
-]
-
-[[package]]
-name = "gremlinpython"
-version = "3.7.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aenum" },
-    { name = "aiohttp" },
-    { name = "async-timeout" },
-    { name = "isodate" },
-    { name = "nest-asyncio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/bd/706ef9c0589f2742c9860d877151807ec9b0f1a2904a605502247c9f773c/gremlinpython-3.7.3.tar.gz", hash = "sha256:c8144bd1099fdcf072deff9a15e260efa9a1a065220495f799f6fc1ff6b83ef4", size = 52585, upload-time = "2024-10-29T17:46:39.912Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/64/65c9ab3deb11c5e0607c51fcddff3be33a06720cdd08768375720893e994/gremlinpython-3.7.3-py3-none-any.whl", hash = "sha256:56e0da437be3336971761dfeaab8532f0c583aaab760d8783c4a0bb389cfd341", size = 78436, upload-time = "2024-10-29T17:46:38.344Z" },
 ]
 
 [[package]]
@@ -533,15 +503,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
-]
-
-[[package]]
-name = "isodate"
-version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
 ]
 
 [[package]]
@@ -700,18 +661,19 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "0.3.34"
+version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
     { name = "langgraph-prebuilt" },
     { name = "langgraph-sdk" },
+    { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/85/147f69a6b7cd3f91cc9d6d981ed25698b4dfda67ef8d004d938e8b79ab00/langgraph-0.3.34.tar.gz", hash = "sha256:d4107b2101ee4a6f93f33b0fac1064d46ac3491f783200affac29f229ab0b93c", size = 122551, upload-time = "2025-04-24T14:26:55.287Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/18/1e255fc8c36ff5056d797d83c9ca9fd926683ace294a9ba38c4b40599237/langgraph-0.5.2.tar.gz", hash = "sha256:393b767e9d6a129636a9df36edc492499336c71e4ee268e64b9d1299d30e636c", size = 442564, upload-time = "2025-07-09T19:15:20.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/51/6a631ce322422b0b8944dac4d74c23bfa2ca52fbb3ee56c868c4ee033bdb/langgraph-0.3.34-py3-none-any.whl", hash = "sha256:4bf8af313ce7686e8a7597ca5441341ec89f9a9fe73ba1b07c116755efa3117d", size = 148191, upload-time = "2025-04-24T14:26:53.676Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/44/6e6c41a3cc00d533dc91cc5f086862b1fccf34aa0ec9605a2cbd116c6ba0/langgraph-0.5.2-py3-none-any.whl", hash = "sha256:db6b8053bf99887957fe45ec27918f8819c4bba269afde88b538e00e9301a581", size = 143735, upload-time = "2025-07-09T19:15:18.733Z" },
 ]
 
 [[package]]
@@ -729,15 +691,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "0.1.8"
+version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/30/f31f0e076c37d097b53e4cff5d479a3686e1991f6c86a1a4727d5d1f5489/langgraph_prebuilt-0.1.8.tar.gz", hash = "sha256:4de7659151829b2b955b6798df6800e580e617782c15c2c5b29b139697491831", size = 24543, upload-time = "2025-04-03T16:04:19.932Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/11/98134c47832fbde0caf0e06f1a104577da9215c358d7854093c1d835b272/langgraph_prebuilt-0.5.2.tar.gz", hash = "sha256:2c900a5be0d6a93ea2521e0d931697cad2b646f1fcda7aa5c39d8d7539772465", size = 117808, upload-time = "2025-06-30T19:52:48.307Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/72/9e092665502f8f52f2708065ed14fbbba3f95d1a1b65d62049b0c5fcdf00/langgraph_prebuilt-0.1.8-py3-none-any.whl", hash = "sha256:ae97b828ae00be2cefec503423aa782e1bff165e9b94592e224da132f2526968", size = 25903, upload-time = "2025-04-03T16:04:18.993Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/64/6bc45ab9e0e1112698ebff579fe21f5606ea65cd08266995a357e312a4d2/langgraph_prebuilt-0.5.2-py3-none-any.whl", hash = "sha256:1f4cd55deca49dffc3e5127eec12fcd244fc381321002f728afa88642d5ec59d", size = 23776, upload-time = "2025-06-30T19:52:47.494Z" },
 ]
 
 [[package]]
@@ -836,15 +798,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
-name = "nest-asyncio"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
 ]
 
 [[package]]
@@ -1098,7 +1051,6 @@ version = "0.1.0"
 source = { editable = "../program-model" }
 dependencies = [
     { name = "common" },
-    { name = "gremlinpython" },
     { name = "protobuf" },
     { name = "rapidfuzz" },
     { name = "tree-sitter" },
@@ -1108,7 +1060,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "common", editable = "../common" },
-    { name = "gremlinpython", specifier = "==3.7.3" },
     { name = "protobuf", specifier = ">=3.20,<=3.20.3" },
     { name = "rapidfuzz", specifier = "~=3.12.2" },
     { name = "tree-sitter", specifier = ">=0.24.0" },
@@ -1425,10 +1376,10 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "common" },
+    { name = "langchain" },
     { name = "langgraph" },
     { name = "numpy" },
     { name = "program-model" },
-    { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "rapidfuzz" },
     { name = "redis" },
@@ -1446,11 +1397,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "common", editable = "../common" },
-    { name = "langgraph", specifier = "~=0.3.20" },
+    { name = "langchain", specifier = "~=0.3.20" },
+    { name = "langgraph", specifier = "~=0.5.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "~=1.15.0" },
     { name = "numpy", specifier = "~=2.2.3" },
     { name = "program-model", editable = "../program-model" },
-    { name = "pydantic", specifier = "~=2.10.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "~=8.3.4" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "rapidfuzz", specifier = "~=3.12.2" },


### PR DESCRIPTION
Bump dependencies to fix langgraph error from updated lockfiles.

Add a vuln discovery test to catch the error. (I would like to add more extensive testing of langgraph workflows in a future PR).

Note: this fix passes the unit test which reproduced the bug, but due to time it has not been tested with the deployed CRS yet and on other seed-gen tasks.

Closes: https://github.com/trailofbits/buttercup/issues/157
