### PR TITLE
Fix Claude Code action access to fetch the repo

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,6 +31,10 @@ jobs:
           persist-credentials: false
           submodules: true
       - name: Run Claude Code
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/.insteadof"
+          GIT_CONFIG_VALUE_0: "https://github.com/"
         id: claude
         uses: anthropics/claude-code-action@beta
         with:


### PR DESCRIPTION
Configure git executed by the Claude Code action to have access to the repo through env vars, to prevent persistence on disk of credentials.

The action implicitly assumes to have access to the repository when fetching but we are not persisting the credentials after cloning, so the action fails. While the action then retrieves a GITHUB_TOKEN on its own, this is not used by the initial fetch operation.