### PR TITLE
make web-ui: explicitly show web-ui url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ install-cscope:
 	cd external/aixcc-cscope/ && autoreconf -i -s && ./configure && make && sudo make install
 
 web-ui:
-	@echo "Opening web UI..."
+	@echo "Opening web UI (https://localhost:31323/)..."
 	@if ! kubectl get namespace $${BUTTERCUP_NAMESPACE:-crs} >/dev/null 2>&1; then \
 		echo "Error: CRS namespace not found. Deploy first with 'make deploy'."; \
 		exit 1; \


### PR DESCRIPTION
Explicitly print the web UI url in the console in case xdg-open or other tools do not open it.

