### PR TITLE
`make lint` should fail if any component lint fails.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ send-libpng-task:
 # Development targets
 lint:
 	@echo "Linting all Python code..."
-	@for component in common orchestrator fuzzer program-model seed-gen patcher; do \
+	@set -e; for component in common orchestrator fuzzer program-model seed-gen patcher; do \
 		make --no-print-directory lint-component COMPONENT=$$component; \
 	done
 


### PR DESCRIPTION
Previously the failures were printed but the loop would continue. 
The final exit code only depended on the last component checked.

Now `make lint` will stop and fail if at the first failed check.