### PR TITLE
Temporarily disable OTel configuration and Signoz

### DIFF
--- a/scripts/setup-azure.sh
+++ b/scripts/setup-azure.sh
@@ -80,7 +80,8 @@ setup_config() {
     configure_langfuse
     
     # Configure SigNoz deployment (optional)
-    configure_otel
+    # TODO: reenable signoz configuration once it is fixed
+    # configure_otel
 }
 
 # Function to validate configuration

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -28,7 +28,8 @@ setup_config() {
     configure_langfuse
     
     # Configure SigNoz deployment (optional)
-    configure_otel
+    # TODO: reenable signoz configuration once it is fixed
+    # configure_otel
 }
 
 # Function to verify setup


### PR DESCRIPTION
This is a fix until the Signoz deployment is fixed to not block `make undeploy`.

Closes: https://github.com/trailofbits/buttercup/issues/257