### PR TITLE
Fix button width at all times.

### DIFF
--- a/orchestrator/src/buttercup/orchestrator/ui/static/script.js
+++ b/orchestrator/src/buttercup/orchestrator/ui/static/script.js
@@ -43,6 +43,15 @@ const elements = {
 
 // Initialize the dashboard
 document.addEventListener('DOMContentLoaded', function() {
+    // Preserve button widths to prevent size changes during refresh
+    const buttons = ['refresh-btn', 'submit-task-btn', 'submit-example-btn'];
+    buttons.forEach(id => {
+        const button = document.getElementById(id);
+        if (button) {
+            button.style.width = button.offsetWidth + 'px';
+        }
+    });
+    
     setupEventListeners();
     loadDashboard();
     


### PR DESCRIPTION
When refreshing the webpage, the button widths/heights for `Submit Task`, `Submit libpng task`, and `Refresh` all change sizes.

This is visually distracting to users.

This PR fixes the button sizes dynamically, based on the page's first load.