### PR TITLE
fix PatchInputPov instantiation for patcher process command

### DIFF
--- a/patcher/src/buttercup/patcher/__cli__.py
+++ b/patcher/src/buttercup/patcher/__cli__.py
@@ -45,7 +45,8 @@ def main() -> None:
                     harness_name=command.harness_name,
                     engine=command.engine,
                     sanitizer=command.sanitizer,
-                    pov=Path(command.crash_input_path).read_bytes(),
+                    pov=Path(command.crash_input_path),
+                    pov_token=f"token-{Path(command.crash_input_path).name}",
                     sanitizer_output=Path(command.stacktrace_path).read_bytes(),
                 )
             ],


### PR DESCRIPTION

Hey there,

I wanted to test your guys' patcher in isolation and noticed that the instantiation of the `PatchInputPoV` for the `ProcessCommand` was not respecting the Pydantic model. I fixed `pov` to be the `Path` to the crash_input and added the `pov_token`.
