### PR TITLE
fix: remove insecure URL substring check for GitHub authentication

### DIFF
--- a/orchestrator/src/buttercup/orchestrator/ui/competition_api/services/challenge_service.py
+++ b/orchestrator/src/buttercup/orchestrator/ui/competition_api/services/challenge_service.py
@@ -72,7 +72,7 @@ class ChallengeService:
             github_pat = os.environ.get("GITHUB_PAT")
             github_username = os.environ.get("GITHUB_USERNAME")
 
-            if github_pat and github_username and "github.com" in repo_url:
+            if github_pat and github_username:
                 # For GitHub repositories, use the PAT for authentication
                 if repo_url.startswith("https://github.com/"):
                     # Convert https://github.com/owner/repo.git to https://username:pat@github.com/owner/repo.git


### PR DESCRIPTION
Remove the redundant and insecure 'github.com' in repo_url check that could match malicious URLs. The inner startswith('https://github.com/') check already provides proper security validation.

This addresses CodeQL security warning py/incomplete-url-substring-sanitization.