### PR TITLE
chore: standardize ruff configuration across all components

### DIFF
--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -66,15 +66,6 @@ exclude = [
 select = ["E", "F", "I", "W", "UP"]
 ignore = [
     "COM812", "ISC001",  # Formatter conflicts
-    # Temporarily disabled for standardization PR - re-enable after refactoring:
-    "I001",   # Import block is un-sorted or un-formatted
-    "E501",   # Line too long
-    "W291",   # Trailing whitespace  
-    "UP006",  # Use built-in collection types for type annotations
-    "UP015",  # Unnecessary mode argument
-    "UP035",  # Import from modern locations instead of deprecated typing
-    "UP045",  # Use X | None for type annotations
-    "UP046",  # Use modern generic class syntax
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/fuzzer/pyproject.toml
+++ b/fuzzer/pyproject.toml
@@ -58,15 +58,6 @@ target-version = "py312"
 select = ["E", "F", "I", "W", "UP"]
 ignore = [
     "COM812", "ISC001",  # Formatter conflicts
-    # Temporarily disabled for standardization PR - re-enable after refactoring:
-    "I001",   # Import block is un-sorted or un-formatted
-    "E501",   # Line too long
-    "W291",   # Trailing whitespace  
-    "UP006",  # Use built-in collection types for type annotations
-    "UP015",  # Unnecessary mode argument
-    "UP035",  # Import from modern locations instead of deprecated typing
-    "UP045",  # Use X | None for type annotations
-    "UP046",  # Use modern generic class syntax
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -82,15 +82,6 @@ exclude = [
 select = ["E", "F", "I", "W", "UP"]
 ignore = [
     "COM812", "ISC001",  # Formatter conflicts
-    # Temporarily disabled for standardization PR - re-enable after refactoring:
-    "I001",   # Import block is un-sorted or un-formatted
-    "E501",   # Line too long
-    "UP006",  # Use built-in collection types for type annotations
-    "UP007",  # Use X | Y for type annotations
-    "UP009",  # UTF-8 encoding declaration is unnecessary
-    "UP015",  # Unnecessary mode argument
-    "UP035",  # Import from modern locations instead of deprecated typing
-    "UP045",  # Use X | None for type annotations
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/patcher/pyproject.toml
+++ b/patcher/pyproject.toml
@@ -55,18 +55,6 @@ target-version = "py312"
 select = ["E", "F", "I", "W", "UP"]
 ignore = [
     "COM812", "ISC001",  # Formatter conflicts
-    # Temporarily disabled for standardization PR - re-enable after refactoring:
-    "I001",   # Import block is un-sorted or un-formatted
-    "E501",   # Line too long
-    "W291",   # Trailing whitespace
-    "W293",   # Blank line contains whitespace
-    "UP006",  # Use built-in collection types for type annotations
-    "UP012",  # Unnecessary call to encode as UTF-8
-    "UP015",  # Unnecessary mode argument
-    "UP031",  # Use format specifiers instead of percent format
-    "UP035",  # Import from modern locations instead of deprecated typing
-    "UP045",  # Use X | None for type annotations
-    "UP046",  # Use modern generic class syntax
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/program-model/pyproject.toml
+++ b/program-model/pyproject.toml
@@ -51,22 +51,11 @@ target-version = "py312"
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "UP"]
 ignore = [
-    "COM812",
-    "ISC001", # Formatter conflicts
-    # Temporarily disabled for standardization PR - re-enable after refactoring:
-    "I001",  # Import block is un-sorted or un-formatted
-    "E501",  # Line too long
-    "W291",  # Trailing whitespace  
-    "UP006", # Use built-in collection types for type annotations
-    "UP015", # Unnecessary mode argument
-    "UP032", # Use f-string instead of format call
-    "UP035", # Import from modern locations instead of deprecated typing
-    "UP045", # Use X | None for type annotations
-    "UP046", # Use modern generic class syntax
+    "COM812", "ISC001",  # Formatter conflicts
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["S101", "D"] # Allow asserts, no docstrings in tests
+"tests/**/*.py" = ["S101", "D"]  # Allow asserts, no docstrings in tests
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]

--- a/seed-gen/pyproject.toml
+++ b/seed-gen/pyproject.toml
@@ -78,35 +78,18 @@ warn_unused_configs = true
 warn_unused_ignores = true
 
 [tool.ruff]
-line-length = 100
-include = ["src/**/*.py", "test/**/*.py", "eval/**/*.py"]
+line-length = 120
+target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "UP"]
-# D203 and D213 are incompatible with D211 and D212 respectively.
-# COM812 and ISC001 can cause conflicts when using ruff as a formatter.
-# See https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules.
 ignore = [
-    "D203", "D213", "COM812", "ISC001",
-    # Temporarily disabled for standardization PR - re-enable after refactoring:
-    "I001",   # Import block is un-sorted or un-formatted
-    "E501",   # Line too long
-    "W291",   # Trailing whitespace  
-    "UP006",  # Use built-in collection types for type annotations
-    "UP015",  # Unnecessary mode argument
-    "UP035",  # Import from modern locations instead of deprecated typing
-    "UP045",  # Use X | None for type annotations
-    "UP046",  # Use modern generic class syntax
+    "COM812", "ISC001",  # Formatter conflicts
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"src/seed_gen/_cli.py" = [
-    "T201", # allow `print` in cli module
-]
-"test/**/*.py" = [
-    "D",    # no docstrings in tests
-    "S101", # asserts are expected in tests
-]
+"src/seed_gen/_cli.py" = ["T201"]  # Allow print in CLI modules
+"test/**/*.py" = ["S101", "D"]  # Allow asserts, no docstrings in tests
 [tool.interrogate]
 # don't enforce documentation coverage for packaging, testing, the virtual
 # environment, or the CLI (which is documented separately).


### PR DESCRIPTION
## Summary
This PR standardizes the ruff configuration across all Buttercup components to ensure consistent code quality checks project-wide.

## Changes
### Configuration Standardization
- **Line length**: Set to 120 for all components (was 100 in seed-gen)
- **Target version**: Consistently set to py312
- **Ignore list**: Reduced to only formatter conflicts (COM812, ISC001)

### Enabled Rules (Previously Ignored)
The following rules are now enabled across all components:
- **I001**: Import block formatting
- **E501**: Line too long  
- **W291/W293**: Whitespace issues
- **UP006**: Use built-in collection types for type annotations
- **UP015**: Unnecessary mode argument
- **UP035**: Import from modern locations instead of deprecated typing
- **UP045**: Use X | None for type annotations
- **UP046**: Use modern generic class syntax

## Dependencies
⚠️ **Important**: This PR assumes #309 (ruff auto-fixes) will be merged first. That PR contains all the necessary fixes for the issues these newly enabled rules would flag.

## Review Notes
- Changes are limited to `pyproject.toml` files only
- No code changes in this PR
- All special cases and exclusions (legacy code, generated files) are preserved
- Per-file ignores for tests and CLI modules are maintained

## Testing
Once #309 is merged, running `ruff check .` should pass without errors.

This PR is part of the effort to break down #295 into smaller, reviewable pieces.

🤖 Generated with [Claude Code](https://claude.ai/code)