### PR TITLE
chore: add mypy cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ dist/
 pdm.lock
 .langchain.db
 
+# Mypy type checking cache
+.mypy_cache/
+**/.mypy_cache/
+
 *.bak
 *.orig
 


### PR DESCRIPTION
## Summary
This PR adds mypy cache directories to .gitignore to keep the repository clean.

## Changes
- Added `.mypy_cache/` pattern to .gitignore
- Added `**/.mypy_cache/` to catch nested cache directories

## Rationale
Mypy creates cache directories for type checking that should not be committed:
- They are environment-specific
- They can cause conflicts between different Python versions
- They add unnecessary noise to the repository

This is a small housekeeping change extracted from PR #295.

🤖 Generated with [Claude Code](https://claude.ai/code)