### PR TITLE
fix: resolve pydantic deprecation warnings

### DIFF
--- a/orchestrator/test/test_crs_client.py
+++ b/orchestrator/test/test_crs_client.py
@@ -61,7 +61,7 @@ class TestCRSClient:
         # Verify request was made correctly
         mock_post.assert_called_once_with(
             "http://test-crs:8080/v1/task/",
-            json=sample_task.dict(),
+            json=sample_task.model_dump(),
             auth=("test_user", "test_pass"),
             headers={"Content-Type": "application/json"},
             timeout=30,
@@ -82,7 +82,7 @@ class TestCRSClient:
         # Verify request was made without auth
         mock_post.assert_called_once_with(
             "http://test-crs:8080/v1/task/",
-            json=sample_task.dict(),
+            json=sample_task.model_dump(),
             auth=None,
             headers={"Content-Type": "application/json"},
             timeout=30,


### PR DESCRIPTION
## PR Summary
This small PR resolves the Pydantic deprecation warnings which you can find in the [CI logs](https://github.com/trailofbits/buttercup/actions/runs/17198517005/job/48784807963#step:12:342):
```python
PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
```