### PR TITLE
litellm_config: remove spaces to fix litellm parsing the file

### DIFF
--- a/deployment/k8s/values.yaml
+++ b/deployment/k8s/values.yaml
@@ -155,7 +155,7 @@ task-server:
 
 task-downloader:
   enabled: true
-  
+
 scheduler:
   enabled: true
 
@@ -210,19 +210,19 @@ scratch-cleaner:
 litellm-helm:
   # Override the name to ensure it matches our references
   nameOverride: "litellm"
-  
+
   # Number of workers for the LiteLLM service
   replicaCount: 1
-  
+
   # Set the service port
   service:
     port: 4000
-  
+
   # Image pull secrets for all containers (main, init, and PostgreSQL)
   imagePullSecrets:
     - name: ghcr-auth
     - name: docker-auth
-  
+
   # Configure the built-in PostgreSQL with our desired settings
   postgresql:
     enabled: true
@@ -244,24 +244,24 @@ litellm-helm:
           memory: 256Mi
     readReplicas:
       replicaCount: 0
-  
+
   # Configure database connection properly
   db:
     deployStandalone: true
     endpoint: "buttercup-litellm-postgresql"
     database: "litellm"
     url: "postgresql://litellm_user:litellm_password11@buttercup-litellm-postgresql:5432/litellm"
-  
+
   # Environment variables - only keep DATABASE_URL as backup
   envVars:
     DATABASE_URL: "postgresql://litellm_user:litellm_password11@buttercup-litellm-postgresql:5432/litellm"
     # API keys are now provided through Kubernetes secrets
-  
+
   # Use environment secrets for API keys
   # For subcharts, we need to use a static name that will be templated at the parent level
   environmentSecrets:
     - "buttercup-litellm-api-secrets"
-  
+
   # Direct inclusion of the litellm_config.yaml content
   proxy_config:
     model_list:
@@ -377,11 +377,11 @@ litellm-helm:
 
       - model_name: gemini-pro	
         litellm_params:
-          model: gemini/gemini-pro	
+          model: gemini/gemini-pro
           api_key: os.environ/GEMINI_API_KEY
           tpm: 2000000
           rpm: 150
-        
+
       - model_name: gemini-2.5-flash-exp
         litellm_params:
           model: gemini/gemini-2.5-flash-exp

--- a/litellm/litellm_config.yaml
+++ b/litellm/litellm_config.yaml
@@ -109,13 +109,13 @@ model_list:
       api_key: os.environ/ANTHROPIC_API_KEY
       tpm: 400000
 
-  - model_name: gemini-pro	
+  - model_name: gemini-pro
     litellm_params:
-      model: gemini/gemini-pro	
+      model: gemini/gemini-pro
       api_key: os.environ/GEMINI_API_KEY
       tpm: 2000000
       rpm: 150
-    
+
   - model_name: gemini-2.5-flash-exp
     litellm_params:
       model: gemini/gemini-2.5-flash-exp


### PR DESCRIPTION
A few spaces in the litellm_config.yaml file were preventing litellm from correctly parsing and loading the configuration.