### PR TITLE
patcher: fix run_find_tests_agent timeout

### DIFF
--- a/patcher/src/buttercup/patcher/agents/config.py
+++ b/patcher/src/buttercup/patcher/agents/config.py
@@ -18,6 +18,7 @@ class PatcherConfig(BaseModel):
     max_root_cause_analysis_retries: int = Field(default=3)
     max_patch_strategy_retries: int = Field(default=3)
     max_tests_retries: int = Field(default=5)
+    find_tests_timeout_min: int = Field(default=30)
     ctx_retriever_recursion_limit: int = Field(default=80)
     patch_validation_recursion_limit: int = Field(default=30)
     n_initial_stackframes: int = Field(default=4)


### PR DESCRIPTION
For some reasons, while testing the patcher locally the timeout was not respected (even though I think it was during the competition).

Relying on asyncio fixes the problem.
Plus, this makes the find-tests timeout configurable by setting an `TOB_PATCHER....` env var.