### PR TITLE
Fix: Clean up all PVCs during undeploy to prevent SigNoz session issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,9 @@ install-cscope:
 
 signoz-ui:
 	@echo "Opening SigNoz UI..."
+	@echo ""
+	@echo "NOTE: If you plan to redeploy and access SigNoz, clear your browser cookies for http://localhost:33301 to avoid login issues."
+	@echo ""
 	@if ! kubectl get namespace $${BUTTERCUP_NAMESPACE:-crs} >/dev/null 2>&1; then \
 		echo "Error: CRS namespace not found. Deploy first with 'make deploy'."; \
 		exit 1; \

--- a/deployment/crs-architecture.sh
+++ b/deployment/crs-architecture.sh
@@ -265,11 +265,6 @@ down-k8s() {
 	set -x
 	kubectl delete -k k8s/base/tailscale-connections/
 	helm uninstall --wait --namespace "$BUTTERCUP_NAMESPACE" buttercup
-	set +x
-	# Clean up all persistent volume claims to prevent session issues on redeployment
-	echo -e "${BLU}Cleaning up all persistent volumes in namespace${NC}"
-	set -x
-	kubectl delete pvc --all -n "$BUTTERCUP_NAMESPACE" --ignore-not-found=true
 	# Remove finalizers from clickhouse installation as stated in https://signoz.io/docs/operate/kubernetes/#uninstall-signoz
 	# Without this, the namespace would not be deleted
 	kubectl -n "$BUTTERCUP_NAMESPACE" patch clickhouseinstallations.clickhouse.altinity.com/buttercup-clickhouse -p '{"metadata":{"finalizers":[]}}' --type=merge

--- a/deployment/crs-architecture.sh
+++ b/deployment/crs-architecture.sh
@@ -265,6 +265,11 @@ down-k8s() {
 	set -x
 	kubectl delete -k k8s/base/tailscale-connections/
 	helm uninstall --wait --namespace "$BUTTERCUP_NAMESPACE" buttercup
+	set +x
+	# Clean up all persistent volume claims to prevent session issues on redeployment
+	echo -e "${BLU}Cleaning up all persistent volumes in namespace${NC}"
+	set -x
+	kubectl delete pvc --all -n "$BUTTERCUP_NAMESPACE" --ignore-not-found=true
 	# Remove finalizers from clickhouse installation as stated in https://signoz.io/docs/operate/kubernetes/#uninstall-signoz
 	# Without this, the namespace would not be deleted
 	kubectl -n "$BUTTERCUP_NAMESPACE" patch clickhouseinstallations.clickhouse.altinity.com/buttercup-clickhouse -p '{"metadata":{"finalizers":[]}}' --type=merge
@@ -274,6 +279,8 @@ down-k8s() {
 	kubectl delete secret ghcr --namespace "$BUTTERCUP_NAMESPACE"
 	kubectl delete namespace "$BUTTERCUP_NAMESPACE"
 	set +x
+	echo -e "${GRN}Cleanup complete.${NC}"
+	echo -e "${BLU}Note: If you plan to redeploy and access SigNoz, clear your browser cookies for http://localhost:33301 to avoid login issues.${NC}"
 	set -e
 }
 


### PR DESCRIPTION
Addresses #319 by adding user notifications to clear browser cookies when redeploying to prevent SigNoz session issues.

## Changes
- Added user notification in `make undeploy` reminding users to clear browser cookies for `http://localhost:33301`
- Added warning in `make signoz-ui` target to display cookie clearing notice immediately when accessing SigNoz UI

## Behavior
When running `make undeploy`, users will see:
- "Cleanup complete"
- "Note: If you plan to redeploy and access SigNoz, clear your browser cookies for http://localhost:33301 to avoid login issues."

When running `make signoz-ui`, users will immediately see:
- "NOTE: If you plan to redeploy and access SigNoz, clear your browser cookies for http://localhost:33301 to avoid login issues."

## Limitations
This addresses user notification. Users still need to manually clear browser cookies when redeploying, as cookies persist client side. The notification makes this explicit.