### PR TITLE
deployment: remove a few warnings during deployment

### DIFF
--- a/deployment/k8s/charts/competition-api/values.yaml
+++ b/deployment/k8s/charts/competition-api/values.yaml
@@ -15,4 +15,3 @@ resources:
 
 nodeSelector: {}
 tolerations: []
-affinity: {}

--- a/deployment/k8s/charts/coverage-bot/templates/deployment.yaml
+++ b/deployment/k8s/charts/coverage-bot/templates/deployment.yaml
@@ -34,9 +34,7 @@ spec:
         - name: BUTTERCUP_FUZZER_SAMPLE_SIZE
           value: "{{ .Values.global.coverageBot.sampleSize }}"
         {{- include "buttercup.commonEnv" . | nindent 8 }}
-        {{- include "buttercup.env.nodeData" . | nindent 8 }}
         {{- include "buttercup.env.dockerSocket" . | nindent 8 }}
-        {{- include "buttercup.env.telemetry" . | nindent 8 }}
       volumes:
       {{- include "buttercup.volumes.scratch" . | nindent 6 }}
       {{- include "buttercup.volumes.tasks" . | nindent 6 }}

--- a/deployment/k8s/charts/fuzzer-bot/templates/deployment.yaml
+++ b/deployment/k8s/charts/fuzzer-bot/templates/deployment.yaml
@@ -32,9 +32,7 @@ spec:
           failureThreshold: {{ .Values.healthCheck.failureThreshold | default 2 }}
         env: 
         {{- include "buttercup.commonEnv" . | nindent 8 }}
-        {{- include "buttercup.env.nodeData" . | nindent 8 }}
         {{- include "buttercup.fuzzerBotEnv" . | nindent 8 }}
-        {{- include "buttercup.env.telemetry" . | nindent 8 }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         volumeMounts:

--- a/deployment/k8s/charts/tracer-bot/templates/deployment.yaml
+++ b/deployment/k8s/charts/tracer-bot/templates/deployment.yaml
@@ -40,8 +40,6 @@ spec:
         env:
         {{- include "buttercup.commonEnv" . | nindent 8 }}
         {{- include "buttercup.env.dockerSocket" . | nindent 8 }}
-        {{- include "buttercup.env.nodeData" . | nindent 8 }}
-        {{- include "buttercup.env.telemetry" . | nindent 8 }}
       volumes:
       {{- include "buttercup.volumes.scratch" . | nindent 6 }}
       {{- include "buttercup.volumes.tasks" . | nindent 6 }}

--- a/deployment/k8s/values.yaml
+++ b/deployment/k8s/values.yaml
@@ -256,11 +256,6 @@ litellm-helm:
     database: "litellm"
     url: "postgresql://litellm_user:litellm_password11@buttercup-litellm-postgresql:5432/litellm"
 
-  # Environment variables - only keep DATABASE_URL as backup
-  envVars:
-    DATABASE_URL: "postgresql://litellm_user:litellm_password11@buttercup-litellm-postgresql:5432/litellm"
-    # API keys are now provided through Kubernetes secrets
-
   # Use environment secrets for API keys
   # For subcharts, we need to use a static name that will be templated at the parent level
   environmentSecrets:


### PR DESCRIPTION
There were a few warnings like:
```
Warning: spec.template.spec.containers[1].env[21]: `NODE_DATA_DIR` hides previous definition
```
because the same env vars were included multiple times.