### PR TITLE
Use our modified oss-fuzz

### DIFF
--- a/orchestrator/scripts/task_crs.sh
+++ b/orchestrator/scripts/task_crs.sh
@@ -3,8 +3,8 @@ curl -X 'POST' 'http://127.0.0.1:31323/webhook/trigger_task' -H 'Content-Type: a
     "challenge_repo_url": "https://github.com/tob-challenges/example-libpng",
     "challenge_repo_base_ref": "5bf8da2d7953974e5dfbd778429c3affd461f51a",
     "challenge_repo_head_ref": "challenges/lp-delta-01",
-    "fuzz_tooling_url": "https://github.com/google/oss-fuzz",
-    "fuzz_tooling_ref": "master",
+    "fuzz_tooling_url": "https://github.com/trail-of-forks/oss-fuzz",
+    "fuzz_tooling_ref": "fix-libpng",
     "fuzz_tooling_project_name": "libpng",
     "duration": 1800
 }'


### PR DESCRIPTION
libpng has changed the default branch to libpng18, but that doesn't contain the oss-fuzz files. Let's use our own fork of oss-fuzz for now, until https://github.com/google/oss-fuzz/pull/14080 is ready.