### PR TITLE
seed-gen: add OpenAI model to fallbacks

### DIFF
--- a/seed-gen/src/buttercup/seed_gen/task.py
+++ b/seed-gen/src/buttercup/seed_gen/task.py
@@ -96,6 +96,7 @@ class Task:
         fallbacks = [
             ButtercupLLM.CLAUDE_3_7_SONNET,
             ButtercupLLM.CLAUDE_3_5_SONNET,
+            ButtercupLLM.OPENAI_GPT_4_1,
             ButtercupLLM.GEMINI_PRO,
         ]
         self.llm = Task.get_llm(ButtercupLLM.CLAUDE_4_SONNET, fallbacks)


### PR DESCRIPTION
Add an OpenAI model to the fallback models so that if only OpenAI API Key is provided, the seed-gen component still works.