### PR TITLE
deployment: use more build-bot

### DIFF
--- a/deployment/k8s/values-upstream-minikube.template
+++ b/deployment/k8s/values-upstream-minikube.template
@@ -51,7 +51,7 @@ redis:
       enabled: false
 
 build-bot:
-  replicaCount: 1
+  replicaCount: 3
 
 litellm:
   masterKey: "${LITELLM_MASTER_KEY}"


### PR DESCRIPTION
Every time i deploy buttercup i actually increase the build-bot replicas because otherwise it takes too long to reach fuzzing/etc. This is pretty cheap on resources and should work well.

WDYT?