### PR TITLE
Fix CRS_KEY_TOKEN_HASH truncation in setup-local

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -624,9 +624,7 @@ generate_crs_key_id_token() {
 
     portable_sed "s|.*export CRS_KEY_ID=.*|export CRS_KEY_ID=\"$crs_key_id\"|" deployment/env
     portable_sed "s|.*export CRS_KEY_TOKEN=.*|export CRS_KEY_TOKEN=\"$crs_key_token\"|" deployment/env
-    # Escape $ characters in the hash so sed treats them as literals (Argon2id hashes contain multiple $)
-    local escaped_hash="${crs_key_token_hash//\$/\\$}"
-    portable_sed "s|.*export CRS_KEY_TOKEN_HASH=.*|export CRS_KEY_TOKEN_HASH='$escaped_hash'|" deployment/env
+    portable_sed "s|.*export CRS_KEY_TOKEN_HASH=.*|export CRS_KEY_TOKEN_HASH='$crs_key_token_hash'|" deployment/env
     print_success "CRS key ID/token configured successfully"
 }
 


### PR DESCRIPTION
  - auth_tool.py: Use plain print() when piped; Rich wraps at 80 chars
  - common.sh: Escape $ in hash before sed (interpreted as backreferences)