### PR TITLE
ui: show error banner instead of mock data when API unavailable

### DIFF
--- a/orchestrator/src/buttercup/orchestrator/ui/static/styles.css
+++ b/orchestrator/src/buttercup/orchestrator/ui/static/styles.css
@@ -355,14 +355,31 @@ body {
 }
 
 @keyframes slideIn {
-    from { 
-        transform: translateX(100%); 
-        opacity: 0; 
+    from {
+        transform: translateX(100%);
+        opacity: 0;
     }
-    to { 
-        transform: translateX(0); 
-        opacity: 1; 
+    to {
+        transform: translateX(0);
+        opacity: 1;
     }
+}
+
+/* API error banner */
+.api-error-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background-color: #f44336;
+    color: white;
+    padding: 0.75rem 1rem;
+    font-weight: 500;
+    text-align: center;
+}
+
+.api-error-banner .error-icon {
+    font-size: 1.2rem;
 }
 
 /* Error message styling for backend errors */


### PR DESCRIPTION
When the web-ui server stops while a browser window is open, the UI was showing fake task data (libpng-analysis, libxml2-fuzzing) instead of indicating the server was unavailable.

Changes:
- Remove getMockTasks() function that returned hardcoded fake data
- Add apiError state to track API connection status
- Update loadTasks() to set empty array and error flag on failure
- Add updateApiErrorBanner() to show/hide error banner
- Add CSS styles for the error banner

Fixes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)