### PR TITLE
Fix port-forward cleanup to only kill specific process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,11 +132,11 @@ send-integration-task:
 		echo "Error: CRS namespace not found. Deploy first with 'make deploy'."; \
 		exit 1; \
 	fi
-	kubectl port-forward -n $${BUTTERCUP_NAMESPACE:-crs} service/buttercup-ui 31323:1323 &
-	@sleep 3
-	./orchestrator/scripts/task_integration_test.sh
-	pkill -f "kubectl port-forward" || true
-	exit 0
+	@kubectl port-forward -n $${BUTTERCUP_NAMESPACE:-crs} service/buttercup-ui 31323:1323 & \
+	PORT_FORWARD_PID=$$!; \
+	sleep 3; \
+	./orchestrator/scripts/task_integration_test.sh; \
+	kill $$PORT_FORWARD_PID 2>/dev/null || true
 
 send-libpng-task:
 	@echo "Running libpng task..."
@@ -144,11 +144,11 @@ send-libpng-task:
 		echo "Error: CRS namespace not found. Deploy first with 'make deploy'."; \
 		exit 1; \
 	fi
-	kubectl port-forward -n $${BUTTERCUP_NAMESPACE:-crs} service/buttercup-ui 31323:1323 &
-	@sleep 3
-	./orchestrator/scripts/task_crs.sh
-	pkill -f "kubectl port-forward" || true
-	exit 0
+	@kubectl port-forward -n $${BUTTERCUP_NAMESPACE:-crs} service/buttercup-ui 31323:1323 & \
+	PORT_FORWARD_PID=$$!; \
+	sleep 3; \
+	./orchestrator/scripts/task_crs.sh; \
+	kill $$PORT_FORWARD_PID 2>/dev/null || true
 
 # Development targets
 lint:


### PR DESCRIPTION
Previously, `send-integration-task` and `send-libpng-task` used `pkill -f "kubectl port-forward"` which killed ALL kubectl port-forward processes. This was problematic when other port-forwards were running.

Now each target captures the PID of the port-forward it starts and kills only that specific process when done.

Closes #404 