### PR TITLE
Fix minikube docker-env eval by forcing Bash output

### DIFF
--- a/deployment/crs-architecture.sh
+++ b/deployment/crs-architecture.sh
@@ -107,7 +107,7 @@ up() {
 				minikube status
 
 				echo -e "${BLU}Building local docker images${NC}"
-				eval $(minikube docker-env)
+				eval "$(minikube docker-env --shell bash)"
 
 				# Authenticate with GitHub Container Registry for Docker builds
 				if [ -n "$GHCR_AUTH" ]; then


### PR DESCRIPTION
Force minikube `docker-env` to emit Bash syntax (--shell bash) to prevent (for example) Fish `set -gx` output from breaking eval in Bash scripts. 

This fixes `crs-architecture.sh: line 110: set: -g: invalid option` kind of issues when running Buttercup on non-Bash shells. 