### PR TITLE
build(deps): pin protobuf to 3.20.3 in fuzzer_runner for OSS-Fuzz compatibility

### DIFF
--- a/fuzzer_runner/pyproject.toml
+++ b/fuzzer_runner/pyproject.toml
@@ -25,6 +25,11 @@ packages = ["src/buttercup"]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.uv]
+# Must match OSS-Fuzz protobuf version for compatibility
+# See: https://github.com/google/oss-fuzz/blob/master/infra/base-images/base-builder/Dockerfile
+constraint-dependencies = ["protobuf==3.20.3"]
+
 [tool.uv.sources]
 common = { path = "../common", editable = true }
 

--- a/fuzzer_runner/uv.lock
+++ b/fuzzer_runner/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = "==3.12.*"
 
+[manifest]
+constraints = [{ name = "protobuf", specifier = "==3.20.3" }]
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
## Summary

- Add uv `constraint-dependencies` to pin protobuf at 3.20.3 in fuzzer_runner
- This version must match OSS-Fuzz infrastructure for compatibility
- Prevents dependabot from creating PRs like #453 that would break the fuzzer runner

## Context

The fuzzer_runner depends on `clusterfuzz` which transitively pulls in `protobuf`. Dependabot was attempting to update protobuf in the lock file (see #453), but this would break compatibility with OSS-Fuzz which uses protobuf 3.20.3.

The `constraint-dependencies` feature in uv explicitly pins protobuf and documents why in the pyproject.toml.

## Test plan

- [x] `uv lock` regenerates successfully with constraint
- [x] protobuf remains at 3.20.3 in uv.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)