### PR TITLE
ci: shell-quote env values in system-integration workflow

### DIFF
--- a/.github/ci-env.template
+++ b/.github/ci-env.template
@@ -14,15 +14,3 @@ export OTEL_PROTOCOL="http"
 export LANGFUSE_ENABLED=true
 export DOCKER_USERNAME=""
 export DOCKER_PAT=""
-
-# Secrets/Env replaced
-export OTEL_ENDPOINT=replace-me
-export OTEL_TOKEN=replace-me
-export BUTTERCUP_NAMESPACE=replace-me
-export GHCR_AUTH=replace-me
-export OPENAI_API_KEY=replace-me
-export ANTHROPIC_API_KEY=replace-me
-export GEMINI_API_KEY=replace-me
-export LANGFUSE_HOST=replace-me
-export LANGFUSE_PUBLIC_KEY=replace-me
-export LANGFUSE_SECRET_KEY=replace-me

--- a/.github/workflows/system-integration.yml
+++ b/.github/workflows/system-integration.yml
@@ -98,30 +98,37 @@ jobs:
           OTEL_EP: ${{ secrets.OTEL_ENDPOINT }}
           OTEL_TK: ${{ secrets.OTEL_TOKEN }}
         run: |
-          cp ../.github/ci-env.template env
-          # Remove GHCR_AUTH line and lines for values we'll append
-          sed -i "/^GHCR_AUTH=/d" env
-          sed -i "/^BUTTERCUP_NAMESPACE=/d" env
-          sed -i "/^OPENAI_API_KEY=/d" env
-          sed -i "/^ANTHROPIC_API_KEY=/d" env
-          sed -i "/^GEMINI_API_KEY=/d" env
-          sed -i "/^LANGFUSE_HOST=/d" env
-          sed -i "/^LANGFUSE_PUBLIC_KEY=/d" env
-          sed -i "/^LANGFUSE_SECRET_KEY=/d" env
-          sed -i "/^OTEL_ENDPOINT=/d" env
-          sed -i "/^OTEL_TOKEN=/d" env
-          # Append values safely using echo (avoids sed injection with special chars)
-          {
-            echo "BUTTERCUP_NAMESPACE=${BUTTERCUP_NS}"
-            echo "OPENAI_API_KEY=${OPENAI_KEY}"
-            echo "ANTHROPIC_API_KEY=${ANTHROPIC_KEY}"
-            echo "GEMINI_API_KEY=${GEMINI_KEY}"
-            echo "LANGFUSE_HOST=${LF_HOST}"
-            echo "LANGFUSE_PUBLIC_KEY=${LF_PUBLIC_KEY}"
-            echo "LANGFUSE_SECRET_KEY=${LF_SECRET_KEY}"
-            echo "OTEL_ENDPOINT=${OTEL_EP}"
-            echo "OTEL_TOKEN=${OTEL_TK}"
-          } >> "env"
+          # The env file is consumed by deployment/crs-architecture.sh via
+          # `source ./env`, so every value must be shell-quoted. Unquoted
+          # values containing whitespace or metacharacters would otherwise be
+          # interpreted as commands at source time.
+          strip_var() {
+            # Match the assignment with or without a leading `export`,
+            # so template lines like `export KEY=replace-me` are removed.
+            sed -i -E "/^[[:space:]]*(export[[:space:]]+)?$1=/d" ./env
+          }
+          write_var() {
+            # printf %q produces a value that is safe to re-parse as bash
+            # input, defending against shell injection from secret contents.
+            printf 'export %s=%q\n' "$1" "$2" >> ./env
+          }
+
+          cp ../.github/ci-env.template ./env
+          for var in GHCR_AUTH BUTTERCUP_NAMESPACE \
+                     OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY \
+                     LANGFUSE_HOST LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY \
+                     OTEL_ENDPOINT OTEL_TOKEN; do
+            strip_var "$var"
+          done
+          write_var BUTTERCUP_NAMESPACE  "$BUTTERCUP_NS"
+          write_var OPENAI_API_KEY       "$OPENAI_KEY"
+          write_var ANTHROPIC_API_KEY    "$ANTHROPIC_KEY"
+          write_var GEMINI_API_KEY       "$GEMINI_KEY"
+          write_var LANGFUSE_HOST        "$LF_HOST"
+          write_var LANGFUSE_PUBLIC_KEY  "$LF_PUBLIC_KEY"
+          write_var LANGFUSE_SECRET_KEY  "$LF_SECRET_KEY"
+          write_var OTEL_ENDPOINT        "$OTEL_EP"
+          write_var OTEL_TOKEN           "$OTEL_TK"
         working-directory: deployment
 
       - name: Run CRS

--- a/.github/workflows/system-integration.yml
+++ b/.github/workflows/system-integration.yml
@@ -98,28 +98,15 @@ jobs:
           OTEL_EP: ${{ secrets.OTEL_ENDPOINT }}
           OTEL_TK: ${{ secrets.OTEL_TOKEN }}
         run: |
-          # The env file is consumed by deployment/crs-architecture.sh via
-          # `source ./env`, so every value must be shell-quoted. Unquoted
-          # values containing whitespace or metacharacters would otherwise be
-          # interpreted as commands at source time.
-          strip_var() {
-            # Match the assignment with or without a leading `export`,
-            # so template lines like `export KEY=replace-me` are removed.
-            sed -i -E "/^[[:space:]]*(export[[:space:]]+)?$1=/d" ./env
-          }
+          # The env file is sourced by deployment/crs-architecture.sh, so every
+          # value must be shell-quoted. printf %q produces a form bash can
+          # re-parse as the literal string, defending against shell injection
+          # from secret contents (whitespace, $(), backticks, quotes, etc.).
           write_var() {
-            # printf %q produces a value that is safe to re-parse as bash
-            # input, defending against shell injection from secret contents.
             printf 'export %s=%q\n' "$1" "$2" >> ./env
           }
 
           cp ../.github/ci-env.template ./env
-          for var in GHCR_AUTH BUTTERCUP_NAMESPACE \
-                     OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY \
-                     LANGFUSE_HOST LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY \
-                     OTEL_ENDPOINT OTEL_TOKEN; do
-            strip_var "$var"
-          done
           write_var BUTTERCUP_NAMESPACE  "$BUTTERCUP_NS"
           write_var OPENAI_API_KEY       "$OPENAI_KEY"
           write_var ANTHROPIC_API_KEY    "$ANTHROPIC_KEY"


### PR DESCRIPTION
## Summary

The weekly **System Integration Tests** workflow has been failing on every Sunday cron since 2026-02-01 — every run we have history for. The job dies in the very first deploy step:

```
./env: line 37: nabHtGdmw4...: command not found
make[1]: *** [Makefile:26: up] Error 127
make: *** [Makefile:95: deploy] Error 2
```

## Root cause

Two compounding bugs in the `Configure env file for minikube` step:

1. **Deletion regex never matched.** The step ran `sed -i "/^KEY=/d" env` for each secret key, but `ci-env.template` has every line prefixed with `export ` (e.g. `export OTEL_TOKEN=replace-me`). The anchor `^OTEL_TOKEN=` never matches `export OTEL_TOKEN=`, so the placeholder lines stayed in the file alongside the appended real values. For most secrets (plain alphanumeric) this was harmless because the second assignment shadowed the first at `source` time.

2. **Appended values were not shell-quoted.** `deployment/crs-architecture.sh:16` does `source ./env`, so each line is parsed as bash. The step appended values via `echo "OTEL_TOKEN=${OTEL_TK}"`, with no quoting. The `OTEL_TOKEN` secret is a `Bearer <token>` header — the space causes bash to parse `OTEL_TOKEN=Bearer` as the assignment and then attempt to execute `<token>` as a command. Hence `command not found` and exit 127.

The same gap was a code-execution sink: a secret containing `$(...)` or backticks would have run on the runner at `source` time. Reproduction confirmed `OTEL_TK="$(touch /tmp/PWNED)"` produced the file under the previous code.

## Fix

Two changes that reinforce each other:

- **`.github/ci-env.template`** — drop the entire `# Secrets/Env replaced` block. Those `export KEY=replace-me` lines only existed because the pre-rewrite approach used `sed -i "s|KEY=.*|KEY=...|"`, which needed substitution targets. The current approach doesn't, so they're vestigial. Removing them eliminates the whole delete-then-rewrite dance and the regex bug class with it.
- **`.github/workflows/system-integration.yml`** — write each secret with `printf 'export %s=%q\n'`. `%q` produces a value that bash can re-parse as the literal string, regardless of whitespace, quotes, `$()`, backticks, or newlines.

After the change, the step is:

```bash
write_var() {
  printf 'export %s=%q\n' "$1" "$2" >> ./env
}
cp ../.github/ci-env.template ./env
write_var BUTTERCUP_NAMESPACE  "$BUTTERCUP_NS"
write_var OPENAI_API_KEY       "$OPENAI_KEY"
# ... etc
```

`GHCR_AUTH` is no longer defined anywhere, so `[ -n "$GHCR_AUTH" ]` in `crs-architecture.sh:63` takes the warning-only else branch as intended (Docker pulls from a public ghcr.io image set in this CI configuration, no authentication required).

## Verification

- `actionlint` (with embedded shellcheck) clean on both changed files.
- Reproduced the original failure shape under the new code: env file generates with shell-escaped values, `source ./env` succeeds, value reads back intact, no leftover `replace-me` lines, `GHCR_AUTH` correctly unset.
- Reproduced the same input under the previous code: `source` fails with `unexpected EOF` and `replace-me` placeholders remain in the file (matches production failure pattern).
- Reproduced the injection: under the previous code, a value containing `$(touch ...)` executed the command on `source`; under the new code it is escaped and stored as a literal string.

## Test plan

- [ ] Merge.
- [ ] Trigger the workflow via `workflow_dispatch` to confirm `make deploy` proceeds past the env-source step before relying on the next Sunday cron.
- [ ] Confirm the next scheduled Sunday run reaches at least the fuzzer-build step (subsequent steps depend on infrastructure beyond this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)