### PR TITLE
fix(setup-local): detect existing buildx, fall back to docker-buildx pkg

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -73,9 +73,19 @@ install_docker() {
     fi
     
     # Install buildx plugin (required for deploy target)
-    print_status "Installing Docker buildx plugin..."
-    sudo apt install -y docker-buildx-plugin
-    print_success "Docker buildx plugin installed"
+    if docker buildx version >/dev/null 2>&1; then
+        print_success "Docker buildx plugin is already installed"
+    else
+        print_status "Installing Docker buildx plugin..."
+        # Package name differs by source: Docker's official apt repo ships
+        # `docker-buildx-plugin`, while Ubuntu's repos ship `docker-buildx`.
+        if apt-cache show docker-buildx-plugin >/dev/null 2>&1; then
+            sudo apt install -y docker-buildx-plugin
+        else
+            sudo apt install -y docker-buildx
+        fi
+        print_success "Docker buildx plugin installed"
+    fi
 }
 
 install_uv() {


### PR DESCRIPTION
## Summary

- `make setup-local` always ran `sudo apt install -y docker-buildx-plugin`, which fails on systems where Docker was installed from Ubuntu's apt repos rather than `get.docker.com` — Ubuntu ships the same plugin under the package name `docker-buildx`.
- `install_docker` now skips the install when `docker buildx version` already works, and probes `apt-cache` to pick whichever of `docker-buildx-plugin` / `docker-buildx` is available.

## Test plan

- [x] On a host with `docker-buildx` (Ubuntu pkg) already installed: `install_docker` reports "Docker buildx plugin is already installed" and exits 0.
- [ ] On a fresh Ubuntu host without Docker's official apt repo: install falls through to `sudo apt install -y docker-buildx`.
- [ ] On a host set up via `get.docker.com` (Docker's apt repo present): install uses `docker-buildx-plugin` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)