### PR TITLE
fix(scripts): make install_uv resilient to missing env helper

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -82,8 +82,22 @@ install_uv() {
     print_status "Installing uv..."
     if ! command_exists uv; then
         curl -fsSL https://astral.sh/uv/install.sh | sh
-        print_status "Sourcing uv environment..."
-        source "$HOME/.local/bin/env"
+        print_status "Loading uv into PATH..."
+        # Newer uv installers drop a helper at $HOME/.local/bin/env; older
+        # ones do not. Source it when present and always ensure the install
+        # dir is on PATH so the freshly-installed binary is reachable.
+        if [ -f "$HOME/.local/bin/env" ]; then
+            # shellcheck disable=SC1091
+            source "$HOME/.local/bin/env"
+        fi
+        case ":$PATH:" in
+            *":$HOME/.local/bin:"*) ;;
+            *) export PATH="$HOME/.local/bin:$PATH" ;;
+        esac
+        if ! command_exists uv; then
+            print_error "uv install completed but 'uv' is not on PATH"
+            return 1
+        fi
         print_success "uv installed successfully"
     else
         print_success "uv is already installed"


### PR DESCRIPTION
## Summary
- `install_uv` in `scripts/common.sh` unconditionally `source`d `$HOME/.local/bin/env` after the uv installer ran, which breaks setup when that helper file is not created (older uv installers, or when the install path differs). Failure mode: `No such file or directory` on the `source` line.
- Source the helper only when it exists, prepend `$HOME/.local/bin` to `PATH` as a fallback, and fail loudly if `uv` is still unreachable after the install.

## Test plan
- [ ] Run a clean setup on a host without prior uv install — `install_uv` completes and subsequent `uv` invocations succeed.
- [ ] Re-run setup on a host where `uv` is already present — function takes the `already installed` branch unchanged.
- [ ] Simulate an install where `$HOME/.local/bin/env` is absent (e.g. delete it before sourcing) — `install_uv` still puts `uv` on `PATH` instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)