### PR TITLE
Add compose.prebuilt.yaml overlay for prebuilt GHCR images

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -40,6 +40,9 @@ jobs:
           python3 -c "
           import yaml
           from pathlib import Path
+          # Docker Compose merge tags are valid in compose files but unknown to safe_load
+          for _t in ('!reset', '!override'):
+              yaml.SafeLoader.add_constructor(_t, lambda loader, node: None)
           for f in Path('.').rglob('*.yaml'):
               if 'deployment/k8s' not in str(f):
                   list(yaml.safe_load_all(f.read_text()))

--- a/dev/docker-compose/README.md
+++ b/dev/docker-compose/README.md
@@ -35,6 +35,7 @@ BUTTERCUP_IMAGE_TAG=<branch-or-tag> docker compose -f compose.yaml -f compose.pr
 - `env.template` - Template for environment variables (copy to `.env` and customize)
 - `env.dev.compose` - Development-specific environment configuration
 - `compose.yaml` - Main compose file with all services
+- `compose.prebuilt.yaml` - Overlay that pulls prebuilt GHCR images instead of building locally
 
 ## Notes
 

--- a/dev/docker-compose/README.md
+++ b/dev/docker-compose/README.md
@@ -18,6 +18,18 @@ cd dev/docker-compose && docker-compose --profile graphdb up -d
 cd dev/docker-compose && docker-compose down
 ```
 
+### Using prebuilt images (skip local builds)
+
+`compose.prebuilt.yaml` is an overlay that replaces every locally-built
+component with its prebuilt image from GHCR, so nothing is built locally:
+
+```bash
+cd dev/docker-compose && docker compose -f compose.yaml -f compose.prebuilt.yaml up -d
+
+# Pin a specific image tag (defaults to "main"):
+BUTTERCUP_IMAGE_TAG=<branch-or-tag> docker compose -f compose.yaml -f compose.prebuilt.yaml up -d
+```
+
 ## Configuration
 
 - `env.template` - Template for environment variables (copy to `.env` and customize)

--- a/dev/docker-compose/compose.prebuilt.yaml
+++ b/dev/docker-compose/compose.prebuilt.yaml
@@ -1,0 +1,54 @@
+# Overlay for compose.yaml that pulls the prebuilt component images from GHCR
+# instead of building them locally. It only overrides the services that have a
+# `build:` block, resetting it and pointing at the published image.
+#
+# Usage (from dev/docker-compose):
+#   docker compose -f compose.yaml -f compose.prebuilt.yaml up -d
+#
+# Override the image tag (defaults to "main"):
+#   BUTTERCUP_IMAGE_TAG=<branch-or-tag> docker compose -f compose.yaml -f compose.prebuilt.yaml up -d
+
+services:
+  program-model:
+    build: !reset null
+    image: ghcr.io/trailofbits/buttercup/buttercup-program-model:${BUTTERCUP_IMAGE_TAG:-main}
+
+  coverage-bot:
+    build: !reset null
+    image: ghcr.io/trailofbits/buttercup/buttercup-fuzzer:${BUTTERCUP_IMAGE_TAG:-main}
+
+  build-bot:
+    build: !reset null
+    image: ghcr.io/trailofbits/buttercup/buttercup-fuzzer:${BUTTERCUP_IMAGE_TAG:-main}
+
+  tracer-bot:
+    build: !reset null
+    image: ghcr.io/trailofbits/buttercup/buttercup-fuzzer:${BUTTERCUP_IMAGE_TAG:-main}
+
+  fuzzer-bot:
+    build: !reset null
+    image: ghcr.io/trailofbits/buttercup/buttercup-fuzzer:${BUTTERCUP_IMAGE_TAG:-main}
+
+  task-downloader:
+    build: !reset null
+    image: ghcr.io/trailofbits/buttercup/buttercup-orchestrator:${BUTTERCUP_IMAGE_TAG:-main}
+
+  task-server:
+    build: !reset null
+    image: ghcr.io/trailofbits/buttercup/buttercup-orchestrator:${BUTTERCUP_IMAGE_TAG:-main}
+
+  scheduler:
+    build: !reset null
+    image: ghcr.io/trailofbits/buttercup/buttercup-orchestrator:${BUTTERCUP_IMAGE_TAG:-main}
+
+  seed-gen:
+    build: !reset null
+    image: ghcr.io/trailofbits/buttercup/buttercup-seed-gen:${BUTTERCUP_IMAGE_TAG:-main}
+
+  patcher:
+    build: !reset null
+    image: ghcr.io/trailofbits/buttercup/buttercup-patcher:${BUTTERCUP_IMAGE_TAG:-main}
+
+  buttercup-ui:
+    build: !reset null
+    image: ghcr.io/trailofbits/buttercup/buttercup-orchestrator:${BUTTERCUP_IMAGE_TAG:-main}


### PR DESCRIPTION
## Summary

Adds `dev/docker-compose/compose.prebuilt.yaml`, an overlay on top of `compose.yaml` that lets developers run the stack from the published GHCR images instead of building every component locally.

- For each of the 11 locally-built services, the overlay resets the base `build:` block (via the Compose `!reset null` merge tag) and points `image:` at the matching prebuilt image: `ghcr.io/trailofbits/buttercup/buttercup-{program-model,fuzzer,orchestrator,seed-gen,patcher}`.
- Image tag defaults to `main`, overridable via `BUTTERCUP_IMAGE_TAG`.
- Infra services (redis, litellm, postgres, dind) are inherited untouched from the base file.
- README updated with usage instructions.

## Usage

```bash
cd dev/docker-compose && docker compose -f compose.yaml -f compose.prebuilt.yaml up -d
# pin a tag:
BUTTERCUP_IMAGE_TAG=<branch-or-tag> docker compose -f compose.yaml -f compose.prebuilt.yaml up -d
```

## Testing

`docker compose -f compose.yaml -f compose.prebuilt.yaml config` confirms every built service resolves to `build=<none>` with the correct GHCR `image:`, and no other service changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)