### PR TITLE
fix(docker-compose): serve buttercup-ui on 31323 internally

### DIFF
--- a/dev/docker-compose/compose.yaml
+++ b/dev/docker-compose/compose.yaml
@@ -312,7 +312,7 @@ services:
       dockerfile: ./orchestrator/Dockerfile
     command: ["buttercup-ui"]
     ports:
-      - "127.0.0.1:31323:1323"
+      - "127.0.0.1:31323:31323"
     env_file:
       - env.dev.compose
       - .env

--- a/dev/docker-compose/env.dev.compose
+++ b/dev/docker-compose/env.dev.compose
@@ -90,6 +90,10 @@ TRACED_VULNERABILITIES_TASK_TIMEOUT_MS=120000
 
 BUTTERCUP_UI_HOST=buttercup-ui
 BUTTERCUP_UI_EXTERNAL_HOST=buttercup-ui
+# Serve on 31323 internally too, so container-to-container URLs
+# (BUTTERCUP_*_COMPETITION_API_URL=http://buttercup-ui:31323) and the
+# host-published port both use one consistent port.
+BUTTERCUP_UI_PORT=31323
 BUTTERCUP_UI_CRS_BASE_URL="http://task-server:8000"
 BUTTERCUP_UI_STORAGE_DIR="/tmp/buttercup-ui"
 BUTTERCUP_UI_LOG_LEVEL="info"


### PR DESCRIPTION
## Problem

`scheduler` and `task-server` are configured to reach the UI/competition API at
`http://buttercup-ui:31323`:

```
# dev/docker-compose/env.dev.compose
BUTTERCUP_TASK_SERVER_COMPETITION_API_URL=http://buttercup-ui:31323
BUTTERCUP_SCHEDULER_SERVE__COMPETITION_API_URL=http://buttercup-ui:31323
```

But `buttercup-ui` only listened on the **container-internal port `1323`**
(`BUTTERCUP_UI_PORT` default in `orchestrator/.../ui/config.py`). `31323` was
**only the host-published port** (`compose.yaml`: `127.0.0.1:31323:1323`).

So inside the compose network, `scheduler → http://buttercup-ui:31323` was
**connection-refused**. POV / patch / bundle submissions silently failed with:

```
scheduler-1 | ... buttercup.orchestrator.scheduler.submissions - INFO - [0:<task>] patches=1 Failed to submit POV
```

## Change

Serve the UI on `31323` internally too, so the host port, the internal
container port, and the `*_COMPETITION_API_URL` env all use one consistent
port (no host/internal divergence):

- `dev/docker-compose/env.dev.compose`: add `BUTTERCUP_UI_PORT=31323`
- `dev/docker-compose/compose.yaml`: port mapping `127.0.0.1:31323:1323` → `127.0.0.1:31323:31323`

## Proof it works

Stack brought up via the docker-compose dev stack.

**Before the fix** — from inside the network (run in the `task-server` container):

```
$ python3 -c "import urllib.request; ..."
http://buttercup-ui:1323/   -> 200
http://buttercup-ui:31323/  -> ERR URLError [Errno 111] Connection refused
```

UI startup log confirmed the wrong port:

```
buttercup-ui-1 | ... Starting UI with settings: ... port=1323 ...
buttercup-ui-1 | INFO: Uvicorn running on http://buttercup-ui:1323
```

**After the fix** — recreate `buttercup-ui scheduler task-server`, then re-test:

UI startup log:

```
buttercup-ui-1 | ... Starting UI with settings: ... port=31323 ...
buttercup-ui-1 | INFO: Uvicorn running on http://buttercup-ui:31323
```

Internal connectivity (from `task-server` container):

```
http://buttercup-ui:31323/          -> 200
http://buttercup-ui:31323/v1/ping/  -> 200
```

Host-side access still works (port mapping unchanged on the host side):

```
$ curl -s -o /dev/null -w '%{http_code}' http://localhost:31323/
200
```

Containers stable, 0 restarts:

```
docker-compose-buttercup-ui-1  restarts=0 running
docker-compose-scheduler-1     restarts=0 running
docker-compose-task-server-1   restarts=0 running
```

### Reproduction steps

```bash
cd dev/docker-compose
# bring the stack up (any method; prebuilt overlay shown here)
docker compose -f compose.yaml -f compose.prebuilt.yaml up -d
# internal check — must return 200 (was "Connection refused" before this PR):
docker compose exec -T task-server python3 - <<'PY'
import urllib.request
for u in ("http://buttercup-ui:31323/","http://buttercup-ui:31323/v1/ping/"):
    try: print(u,"->",urllib.request.urlopen(u,timeout=5).status)
    except Exception as e: print(u,"-> ERR",type(e).__name__,getattr(e,"code",e))
PY
# host check — still 200:
curl -s -o /dev/null -w '%{http_code}\n' http://localhost:31323/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
