### PR TITLE
fix(common): use budgeted LITELLM_API_KEY so LITELLM_MAX_BUDGET is enforced

### DIFF
--- a/common/src/buttercup/common/llm.py
+++ b/common/src/buttercup/common/llm.py
@@ -133,9 +133,17 @@ def create_default_llm_with_temperature(**kwargs: Any) -> Runnable:
 
 
 def create_llm(**kwargs: Any) -> BaseChatModel:
-    """Create an LLM object with the given configuration."""
+    """Create an LLM object with the given configuration.
+
+    Prefer ``LITELLM_API_KEY`` (the per-deployment budgeted virtual key created
+    by litellm-user-keys-setup / the k8s key Job) over ``BUTTERCUP_LITELLM_KEY``.
+    ``BUTTERCUP_LITELLM_KEY`` is the litellm *master* key, which bypasses all
+    budget/rate enforcement, so using it directly makes ``LITELLM_MAX_BUDGET``
+    ineffective. Fall back to it only when no budgeted key is provided.
+    """
+    api_key = os.environ.get("LITELLM_API_KEY") or os.environ["BUTTERCUP_LITELLM_KEY"]
     return ChatOpenAI(
         openai_api_base=os.environ["BUTTERCUP_LITELLM_HOSTNAME"],
-        openai_api_key=SecretStr(os.environ["BUTTERCUP_LITELLM_KEY"]),
+        openai_api_key=SecretStr(api_key),
         **kwargs,
     )

--- a/dev/docker-compose/env.template
+++ b/dev/docker-compose/env.template
@@ -2,6 +2,11 @@
 
 # LiteLLM variables
 BUTTERCUP_LITELLM_KEY=sk-1234
+# Max spend (USD) enforced on the generated llm-user LiteLLM key. Once the
+# cumulative spend on that key exceeds this value, LiteLLM rejects further
+# requests. Picked up by compose interpolation in compose.yaml; defaults to 100
+# if unset. Kept low here to cap spend during local development.
+LITELLM_MAX_BUDGET=15
 # You only need to change variables for APIs you will use, but you need all these variables set
 ANTHROPIC_API_KEY=<INSERT_KEY>
 AZURE_API_BASE=<INSERT_HOST>


### PR DESCRIPTION
## Problem

`LITELLM_MAX_BUDGET` was not enforced. An e2e run with `--budget 1` spent
**$4.77** (~5× the cap) with every `/chat/completions` returning `200` and
no throttling.

Root cause: `create_llm()` authenticated the LLM client with
`os.environ["BUTTERCUP_LITELLM_KEY"]`, which `litellm/litellm_config.yaml`
defines as `general_settings.master_key`:

```yaml
general_settings:
  master_key: os.environ/BUTTERCUP_LITELLM_KEY
```

**LiteLLM master keys bypass all budget/rate enforcement.** The budgeted
virtual key is already provisioned and wired in the repo:

- `litellm-user-keys-setup` creates the `llm-user` key with
  `max_budget=$LITELLM_MAX_BUDGET`.
- The seed-gen/patcher service entrypoints already
  `export LITELLM_API_KEY=$(cat /secrets/llm-user_api_key)`.

…but `create_llm()` never read `LITELLM_API_KEY`, so that budgeted key was
created and then ignored — all traffic used the unlimited master key.

## Fix

`create_llm()` now prefers the budgeted `LITELLM_API_KEY` and falls back to
`BUTTERCUP_LITELLM_KEY` only when no budgeted key is provided (so
environments without a provisioned budgeted key are unaffected):

```python
api_key = os.environ.get("LITELLM_API_KEY") or os.environ["BUTTERCUP_LITELLM_KEY"]
```

This is the only missing link — the litellm key plumbing
(`litellm-user-keys-setup` → `llm-user` key with `max_budget` →
`LITELLM_API_KEY` export in seed-gen/patcher) already exists on `main`; this
just makes the client actually use it.

## Proof

Brought up litellm + litellm-db + litellm-user-keys-setup and exercised the
proxy directly with `openai-gpt-4o`:

| Key | `max_budget` | Result |
|-----|--------------|--------|
| Non-master budgeted key | `$0.001` | call 1 → `200`; call 2 → **`HTTP 400 budget_exceeded`** — `"Budget has been exceeded! Current cost: 0.0086325, Max budget: 0.001"` |
| Master key (`BUTTERCUP_LITELLM_KEY`) | master | 8/8 calls → `200`, **never blocked** |

So LiteLLM enforces budgets correctly for a non-master key and bypasses them
for the master key. After this change the components authenticate with the
budgeted `llm-user` key, so that exact (now-enforced) path is used and
`LITELLM_MAX_BUDGET` takes effect.

### Reproduction

```bash
cd dev/docker-compose
docker compose -f compose.yaml -f compose.prebuilt.yaml up -d litellm-db litellm litellm-user-keys-setup
MASTER=$(grep -m1 '^BUTTERCUP_LITELLM_KEY=' .env | cut -d= -f2-)
# create a tiny-budget non-master key via the admin API:
K=$(curl -s -X POST localhost:8080/key/generate -H "Authorization: Bearer $MASTER" \
     -H 'Content-Type: application/json' -d '{"max_budget":0.001,"user":"v"}' \
     | sed -n 's/.*"key"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
# spend past it with gpt-4o -> 2nd call returns 400 budget_exceeded;
# the same loop with $MASTER never blocks.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
