### PR TITLE
fix(docker-compose): point patcher task storage at tasks_storage (not crs_scratch)

### DIFF
--- a/dev/docker-compose/env.dev.compose
+++ b/dev/docker-compose/env.dev.compose
@@ -37,7 +37,11 @@ BUTTERCUP_SCHEDULER_SCRATCH_DIR=/node_data/crs_scratch
 BUTTERCUP_PATCHER_SERVE__REDIS_URL=redis://redis:6379
 BUTTERCUP_PATCHER_SERVE__SLEEP_TIME=5
 BUTTERCUP_PATCHER_LOG_LEVEL=debug
-BUTTERCUP_PATCHER_TASK_STORAGE_DIR=/node_data/crs_scratch
+# Where the downloaded challenge task lives (matches downloader/scheduler).
+# Must NOT be crs_scratch: get_clean_task() resolves <task_storage>/<task_id>,
+# which under crs_scratch collides with the fuzzer's per-task scratch dir
+# (no task_meta.json there) and crashes TaskMeta.load().
+BUTTERCUP_PATCHER_TASK_STORAGE_DIR=/node_data/tasks_storage
 BUTTERCUP_PATCHER_SCRATCH_DIR=/node_data/crs_scratch
 
 BUTTERCUP_PROGRAM_MODEL_SERVE__REDIS_URL=redis://redis:6379


### PR DESCRIPTION
## Problem

During an e2e run the patcher crashed in the `find_tests` node:

```
patcher-1 | FileNotFoundError: [Errno 2] No such file or directory:
            '/node_data/crs_scratch/e7ee28c0-065e-4ce7-b022-cd99c8125259/task_meta.json'
patcher-1 |   File ".../buttercup/common/challenge_task.py", line 1102, in get_clean_task
patcher-1 |   File ".../buttercup/common/challenge_task.py", line 179, in __post_init__
patcher-1 |     self.task_meta = TaskMeta.load(self.read_only_task_dir)
```

Root cause — a shared-volume path collision:

- `BUTTERCUP_PATCHER_TASK_STORAGE_DIR=/node_data/crs_scratch` →
  `configuration.tasks_storage = /node_data/crs_scratch`.
- `ChallengeTask.get_clean_task()` builds `clean_dir = tasks_storage / task_id`
  → `/node_data/crs_scratch/<task_id>`, then
  `node_local.remote_archive_to_dir(clean_dir)` which **early-returns if the
  directory already exists** (`if local_path.exists(): return`).
- But `/node_data/crs_scratch/<task_id>` is already the **fuzzer/scheduler
  per-task scratch dir** (corpus/crashes/build subdirs) — it has no
  `task_meta.json`. So the pristine task is never materialized and
  `TaskMeta.load()` raises `FileNotFoundError`.

The actual downloaded task (with `task_meta.json`, `src/`, `diff/`,
`fuzz-tooling/`) lives at `/node_data/tasks_storage/<task_id>/`, where the
downloader/scheduler put it:

- `BUTTERCUP_DOWNLOADER_DOWNLOAD_DIR=/node_data/tasks_storage`
- `BUTTERCUP_SCHEDULER_TASKS_STORAGE_DIR=/node_data/tasks_storage`
- `BUTTERCUP_PATCHER_TASK_STORAGE_DIR=/node_data/crs_scratch`  ← inconsistent

## Fix

Point the patcher task storage at `/node_data/tasks_storage` (consistent with
downloader/scheduler), so `get_clean_task()` resolves the real task
directory that contains `task_meta.json`. `BUTTERCUP_PATCHER_SCRATCH_DIR`
stays `/node_data/crs_scratch` (scratch is correctly shared).

## Proof

Inspected the shared volume in the running `patcher` and `scheduler`
containers for the failing task `e7ee28c0-…`:

```
/node_data/crs_scratch/e7ee28c0-.../        # what the patcher resolved (wrong)
  buttercup_corpus_libpng_read_fuzzer/      # fuzzer scratch — NO task_meta.json
  buttercup_crashes_libpng_read_fuzzer/
  e7ee28c0-...-13c1c996-.../ (build subdirs)
/node_data/crs_scratch/e7ee28c0-....tgz     # absent (no remote archive)

/node_data/tasks_storage/e7ee28c0-.../      # the real task (correct target)
  diff/  fuzz-tooling/  src/
  task_meta.json                            # 480 bytes  ✓
```

So the data the patcher needs is at `/node_data/tasks_storage/<task_id>/`;
with this change `get_clean_task()` resolves there and `TaskMeta.load()`
succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
