### PR TITLE
fix(program-model): drop redundant deadsnakes PPA on Ubuntu 24.04

### DIFF
--- a/program-model/Dockerfile
+++ b/program-model/Dockerfile
@@ -2,8 +2,6 @@ ARG BASE_IMAGE=ubuntu:24.04
 
 # hadolint ignore=DL3006
 FROM $BASE_IMAGE AS base
-# Ubuntu 24.04 (noble) ships python3.12 in the default archive, so the
-# deadsnakes PPA / software-properties-common is unnecessary here.
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates python3.12 curl \
     && rm -rf /var/lib/apt/lists/*

--- a/program-model/Dockerfile
+++ b/program-model/Dockerfile
@@ -2,10 +2,9 @@ ARG BASE_IMAGE=ubuntu:24.04
 
 # hadolint ignore=DL3006
 FROM $BASE_IMAGE AS base
+# Ubuntu 24.04 (noble) ships python3.12 in the default archive, so the
+# deadsnakes PPA / software-properties-common is unnecessary here.
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && apt-get install -y --no-install-recommends software-properties-common \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates python3.12 curl \
     && rm -rf /var/lib/apt/lists/*
 RUN for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do DEBIAN_FRONTEND=noninteractive apt-get remove $pkg; done || true


### PR DESCRIPTION
Ubuntu 24.04 (noble) ships `python3.12` in the default archive, so the deadsnakes PPA / `software-properties-common` in `program-model/Dockerfile` only added an external launchpad.net dependency for no benefit (seed-gen/patcher already install python3.12 from the default archive). This drops it, matching the other component Dockerfiles and removing an unnecessary network dependency that can fail builds on networks without launchpad access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)