### PR TITLE
feat(scripts): generic oss-fuzz task script + run-oss-fuzz-task skill

### DIFF
--- a/.claude/skills/start-buttercup-compose/SKILL.md
+++ b/.claude/skills/start-buttercup-compose/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: start-buttercup-compose
+description: Start the Buttercup CRS locally with docker compose and wait until the task webhook is up. Use when the user wants to bring up / spin up / start the system locally with docker compose (e.g. "start buttercup", "bring the system up with compose", "spin up the CRS locally"). Defaults to prebuilt GHCR images; build-local on request. To submit a task afterwards, use the `submit-oss-fuzz-task` skill. Not for the Kubernetes/Helm deployment (that is `make deploy`).
+allowed-tools:
+  - Bash
+  - Read
+  - Edit
+  - AskUserQuestion
+---
+
+# Start Buttercup locally with docker compose
+
+Bring the CRS up with docker compose and confirm it is ready to accept tasks.
+Run every command **from the repository root** — the compose file lives in
+`dev/docker-compose/`, but docker compose resolves its relative `env_file`/build
+paths against the compose file's own directory, so passing
+`-f dev/docker-compose/compose.yaml` from the root works and avoids `cd`.
+
+After this skill finishes, submit a task with the `submit-oss-fuzz-task` skill.
+
+## Inputs to gather
+
+- **build mode** (optional): default is **prebuilt GHCR images** (fast, no local
+  build). Use **build-local** only if the user wants their local code changes
+  reflected — it is much slower.
+- **image tag** (optional, prebuilt only): defaults to `main`.
+
+## Step 1 — Require LLM keys in the compose `.env` (hard gate)
+
+The stack reads `dev/docker-compose/.env` for LLM keys and interpolated vars.
+Buttercup cannot do useful work (seed-gen, patcher) without at least one working
+LLM provider key, so **this is a precondition: if none is configured, STOP here
+and do not start the stack.**
+
+First resolve the file. Prefer the `.env` in the current checkout. If it is
+missing and we are in a git worktree, fall back to the **main worktree's** copy —
+`.env` is gitignored, so it usually exists only in the primary checkout — and
+copy it in. Only if neither exists, fall back to the template (placeholders,
+which will fail the gate below):
+
+```bash
+ENV=dev/docker-compose/.env
+if [ ! -f "$ENV" ]; then
+  main_root=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+  if [ -n "$main_root" ] && [ "$main_root" != "$PWD" ] && [ -f "$main_root/$ENV" ]; then
+    echo "Using .env from main worktree: $main_root/$ENV"
+    cp "$main_root/$ENV" "$ENV"
+  fi
+fi
+test -f "$ENV" || cp dev/docker-compose/env.template "$ENV"
+```
+
+(Copying — rather than symlinking — keeps the running stack pinned to the keys
+that were present at start time; re-run this skill to pick up later changes to
+the main `.env`.)
+
+Then require at least one real provider key — a line whose value is neither empty
+nor an `<INSERT...>` placeholder:
+
+```bash
+configured=$(grep -E '^(ANTHROPIC_API_KEY|OPENAI_API_KEY|GEMINI_API_KEY|AZURE_API_KEY)=' \
+  dev/docker-compose/.env | grep -cvE '=\s*(<INSERT[^>]*>)?\s*$')
+if [ "${configured:-0}" -eq 0 ]; then
+  echo "ERROR: no LLM provider key set in dev/docker-compose/.env (all placeholders)." >&2
+  echo "Set at least one of ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY / AZURE_API_KEY, then re-run." >&2
+  exit 1
+fi
+```
+
+If the gate fails, do **not** proceed to Step 2. Tell the user exactly which
+file to edit (`dev/docker-compose/.env`) and which keys to set, and stop. Only
+continue once at least one real key is present.
+
+## Step 2 — Start the stack
+
+**Prebuilt (default):**
+
+```bash
+BUTTERCUP_IMAGE_TAG=main docker compose \
+  -f dev/docker-compose/compose.yaml \
+  -f dev/docker-compose/compose.prebuilt.yaml up -d
+```
+
+Substitute the requested tag for `main` if the user specified one.
+
+**Build-local (only if requested):**
+
+```bash
+docker compose -f dev/docker-compose/compose.yaml up -d --build
+```
+
+The local build compiles every component and can take many minutes. If a build
+fails on a missing `external/buttercup-cscope`, run
+`git submodule update --init external/buttercup-cscope` and retry.
+
+## Step 3 — Wait until the task webhook is up
+
+`buttercup-ui` serves `/webhook/trigger_task` on `127.0.0.1:31323` and has no
+compose healthcheck, so poll it. Allow more time on first run (image pulls or a
+local build):
+
+```bash
+for i in $(seq 1 60); do
+  if curl -fsS -o /dev/null http://127.0.0.1:31323/ ; then echo "UI ready"; break; fi
+  sleep 5
+done
+```
+
+If it never comes up, show recent logs and stop:
+`docker compose -f dev/docker-compose/compose.yaml logs --tail=50 buttercup-ui`.
+
+## Step 4 — Report status
+
+Confirm the stack is up and tell the user what to do next:
+
+```bash
+# service status
+docker compose -f dev/docker-compose/compose.yaml ps
+
+# dashboard
+open http://127.0.0.1:31323/
+
+# follow the pipeline
+docker compose -f dev/docker-compose/compose.yaml logs -f scheduler
+
+# tear down
+docker compose -f dev/docker-compose/compose.yaml down
+```
+
+State that a task can now be submitted with the `submit-oss-fuzz-task` skill.

--- a/.claude/skills/submit-oss-fuzz-task/SKILL.md
+++ b/.claude/skills/submit-oss-fuzz-task/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: submit-oss-fuzz-task
+description: Submit a task against an OSS-Fuzz project to a running local Buttercup CRS via scripts/task_oss_fuzz.sh. Use when the user wants to run / submit / kick off / smoke-test a task on an oss-fuzz project (e.g. "run libpng", "submit an oss-fuzz task for libucl"). Assumes the system is already up; if it is not, start it first with the `start-buttercup-compose` skill.
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+---
+
+# Submit an OSS-Fuzz task to a running Buttercup
+
+Submit a task to an already-running CRS through `scripts/task_oss_fuzz.sh`. Run
+commands **from the repository root**.
+
+If the system is not running yet, bring it up first with the
+`start-buttercup-compose` skill, then come back here.
+
+## Step 0 — Confirm the CRS is up
+
+The script posts to the `buttercup-ui` webhook on `127.0.0.1:31323`. Verify it
+responds first:
+
+```bash
+curl -fsS -o /dev/null http://127.0.0.1:31323/ && echo "CRS up" || echo "CRS not reachable"
+```
+
+If it is not reachable, tell the user to start the system with the
+`start-buttercup-compose` skill (or, if they remapped the port, pass `-u <url>`
+or set `BUTTERCUP_API_URL`).
+
+## Inputs to gather
+
+Parse from the user's request; ask only if a required one is missing.
+
+- **project** (required): the OSS-Fuzz project name (directory under `projects/`
+  in oss-fuzz), e.g. `libpng`, `libucl`.
+- **source repo / refs** (optional): `--repo-url` + `--head-ref`, and
+  `--base-ref` for delta mode. Omit for a minimal task (the oss-fuzz Dockerfile
+  fetches the source).
+- **duration** (optional): seconds, default 1800.
+
+## Step 1 — Submit the task
+
+The script defaults the fuzzing tooling to upstream `google/oss-fuzz @ master`,
+so only `-p` is required:
+
+```bash
+# minimal
+./scripts/task_oss_fuzz.sh -p <project>
+
+# full mode with explicit source
+./scripts/task_oss_fuzz.sh -p <project> -r <repo-url> -b <head-ref> [-d <seconds>]
+
+# delta mode (analyze base..head)
+./scripts/task_oss_fuzz.sh -p <project> -r <repo-url> -B <base-ref> -b <head-ref>
+```
+
+Show the user the exact command and the JSON the server accepts. To preview
+without submitting, add `--dry-run`. Report the webhook response (a task id /
+message id) verbatim.
+
+## Step 2 — Report next steps
+
+Tell the user how to observe progress and where results land:
+
+```bash
+# follow the pipeline
+docker compose -f dev/docker-compose/compose.yaml logs -f scheduler
+
+# dashboard
+open http://127.0.0.1:31323/
+```
+
+Submitted artifacts (PoVs/patches/bundles) land under `tasks_storage/` in the
+repo root and are downloadable from the dashboard.
+
+## Notes & gotchas
+
+- `harnesses_included` is **not** a field on the server's `Challenge` model — the
+  script intentionally omits it. Required fields are `fuzz_tooling_url`,
+  `fuzz_tooling_ref`, `fuzz_tooling_project_name`, `duration`; supplying
+  `challenge_repo_base_ref` switches the task to delta mode and then requires the
+  repo url + head ref.
+- The script's default API URL (`http://127.0.0.1:31323`) already matches the
+  compose port mapping — no `kubectl port-forward` needed (that is for the k8s
+  deployment). Override with `-u <url>` or `BUTTERCUP_API_URL`.

--- a/scripts/task_oss_fuzz.sh
+++ b/scripts/task_oss_fuzz.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+# Trigger a Buttercup task against an arbitrary OSS-Fuzz project.
+#
+# By default this points the fuzzing tooling at upstream
+# https://github.com/google/oss-fuzz @ master, so you only need to pass the
+# project name (the directory under projects/ in oss-fuzz). Optionally provide
+# the challenge source repo/refs; supplying a base ref switches the task to
+# "delta" mode (analyze the diff between base and head).
+#
+# Examples:
+#   # Full mode against an upstream oss-fuzz project
+#   ./task_oss_fuzz.sh -p libpng -r https://github.com/pnggroup/libpng -b libpng16
+#
+#   # Minimal (project only; relies on oss-fuzz Dockerfile to fetch source)
+#   ./task_oss_fuzz.sh -p libucl
+#
+#   # Delta mode (analyze base..head) with a custom oss-fuzz fork
+#   ./task_oss_fuzz.sh -p libxml2 \
+#       -r https://github.com/tob-challenges/afc-libxml2 \
+#       -B <base_sha> -b <head_sha> \
+#       -t https://github.com/tob-challenges/oss-fuzz-aixcc -f <tooling_ref>
+#
+#   # Inspect the payload without sending it
+#   ./task_oss_fuzz.sh -p libpng -r https://github.com/pnggroup/libpng -b libpng16 --dry-run
+
+set -euo pipefail
+
+# --- defaults -----------------------------------------------------------------
+API_URL="${BUTTERCUP_API_URL:-http://127.0.0.1:31323}"
+TOOLING_URL="https://github.com/google/oss-fuzz"
+TOOLING_REF="master"
+DURATION=1800
+
+PROJECT=""
+REPO_URL=""
+HEAD_REF=""
+BASE_REF=""
+NAME=""
+DRY_RUN=0
+
+usage() {
+    cat <<'EOF'
+Trigger a Buttercup task against an arbitrary OSS-Fuzz project.
+
+Defaults point the fuzzing tooling at upstream google/oss-fuzz @ master, so
+the only required argument is the project name. Supplying a base ref switches
+the task into "delta" mode (analyze base..head).
+
+Usage: task_oss_fuzz.sh -p PROJECT [options]
+
+Options:
+  -p, --project NAME        OSS-Fuzz project name (dir under projects/)   [required]
+  -r, --repo-url URL        Challenge source repo URL
+  -b, --head-ref REF        Source branch/tag/commit to analyze
+  -B, --base-ref REF        "Clean" base ref -> enables delta mode
+  -t, --tooling-url URL     oss-fuzz (fork) URL   [default: google/oss-fuzz]
+  -f, --tooling-ref REF     oss-fuzz git ref      [default: master]
+  -d, --duration SECONDS    Analysis time limit   [default: 1800]
+  -n, --name NAME           Friendly task name (optional)
+  -u, --api-url URL         CRS webhook base URL  [default: $BUTTERCUP_API_URL or
+                            http://127.0.0.1:31323]
+      --dry-run             Print the JSON payload and exit
+  -h, --help                Show this help
+
+Examples:
+  task_oss_fuzz.sh -p libpng -r https://github.com/pnggroup/libpng -b libpng16
+  task_oss_fuzz.sh -p libucl
+  task_oss_fuzz.sh -p libpng -r https://github.com/pnggroup/libpng -b libpng16 --dry-run
+EOF
+    exit "${1:-0}"
+}
+
+# --- arg parsing --------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -p|--project)     PROJECT="$2"; shift 2 ;;
+        -r|--repo-url)    REPO_URL="$2"; shift 2 ;;
+        -b|--head-ref)    HEAD_REF="$2"; shift 2 ;;
+        -B|--base-ref)    BASE_REF="$2"; shift 2 ;;
+        -t|--tooling-url) TOOLING_URL="$2"; shift 2 ;;
+        -f|--tooling-ref) TOOLING_REF="$2"; shift 2 ;;
+        -d|--duration)    DURATION="$2"; shift 2 ;;
+        -n|--name)        NAME="$2"; shift 2 ;;
+        -u|--api-url)     API_URL="$2"; shift 2 ;;
+        --dry-run)        DRY_RUN=1; shift ;;
+        -h|--help)        usage 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage 1 ;;
+    esac
+done
+
+if [[ -z "$PROJECT" ]]; then
+    echo "Error: --project is required" >&2
+    usage 1
+fi
+if [[ -n "$BASE_REF" && ( -z "$REPO_URL" || -z "$HEAD_REF" ) ]]; then
+    echo "Error: delta mode (--base-ref) requires --repo-url and --head-ref" >&2
+    exit 1
+fi
+
+# --- build JSON payload -------------------------------------------------------
+# Prefer jq for safe escaping; fall back to manual assembly if jq is absent.
+if command -v jq >/dev/null 2>&1; then
+    PAYLOAD=$(jq -n \
+        --arg name "$NAME" \
+        --arg repo "$REPO_URL" \
+        --arg head "$HEAD_REF" \
+        --arg base "$BASE_REF" \
+        --arg turl "$TOOLING_URL" \
+        --arg tref "$TOOLING_REF" \
+        --arg proj "$PROJECT" \
+        --argjson dur "$DURATION" \
+        '{
+            fuzz_tooling_url: $turl,
+            fuzz_tooling_ref: $tref,
+            fuzz_tooling_project_name: $proj,
+            duration: $dur
+        }
+        + (if $name != "" then {name: $name} else {} end)
+        + (if $repo != "" then {challenge_repo_url: $repo} else {} end)
+        + (if $head != "" then {challenge_repo_head_ref: $head} else {} end)
+        + (if $base != "" then {challenge_repo_base_ref: $base} else {} end)')
+else
+    fields="\"fuzz_tooling_url\": \"$TOOLING_URL\""
+    fields+=", \"fuzz_tooling_ref\": \"$TOOLING_REF\""
+    fields+=", \"fuzz_tooling_project_name\": \"$PROJECT\""
+    fields+=", \"duration\": $DURATION"
+    [[ -n "$NAME"     ]] && fields+=", \"name\": \"$NAME\""
+    [[ -n "$REPO_URL" ]] && fields+=", \"challenge_repo_url\": \"$REPO_URL\""
+    [[ -n "$HEAD_REF" ]] && fields+=", \"challenge_repo_head_ref\": \"$HEAD_REF\""
+    [[ -n "$BASE_REF" ]] && fields+=", \"challenge_repo_base_ref\": \"$BASE_REF\""
+    PAYLOAD="{ $fields }"
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "$PAYLOAD"
+    exit 0
+fi
+
+echo "Submitting task to ${API_URL}/webhook/trigger_task ..." >&2
+curl -fsS -X POST "${API_URL}/webhook/trigger_task" \
+    -H 'Content-Type: application/json' \
+    -d "$PAYLOAD"
+echo


### PR DESCRIPTION
## What

Two additive dev-workflow helpers for spinning up Buttercup locally and testing it against an OSS-Fuzz project.

### `scripts/task_oss_fuzz.sh`
A generic, flag-driven replacement for the per-project `orchestrator/scripts/task_upstream_*.sh` scripts. POSTs to the CRS webhook (`/webhook/trigger_task`) for **any** OSS-Fuzz project.

- Defaults the fuzzing tooling to upstream `google/oss-fuzz @ master` — only `--project` is required.
- Supports full mode, delta mode (`--base-ref` ⇒ requires `--repo-url` + `--head-ref`), custom `--duration`, custom oss-fuzz fork/ref, and `--api-url` / `BUTTERCUP_API_URL`.
- `--dry-run` prints the JSON without submitting.
- Builds the payload with `jq` when available, with a validated jq-less fallback.
- Payload matches the server's `Challenge` model exactly; drops the `harnesses_included` field (not on the model — silently ignored by the older scripts).

```bash
./scripts/task_oss_fuzz.sh -p libpng -r https://github.com/pnggroup/libpng -b libpng16
./scripts/task_oss_fuzz.sh -p libucl                 # minimal
./scripts/task_oss_fuzz.sh -p libpng ... --dry-run   # preview payload
```

### `.claude/skills/run-oss-fuzz-task/`
A Claude Code skill that runs the end-to-end local smoke test:
1. ensures `dev/docker-compose/.env` exists (from the template) and warns on placeholder LLM keys;
2. starts the stack with docker compose — **prebuilt GHCR images by default**, `build-local` on request;
3. waits for the `buttercup-ui` webhook on `127.0.0.1:31323`;
4. submits the task via `scripts/task_oss_fuzz.sh`;
5. reports log-follow / dashboard / teardown commands.

## Notes
- No changes to existing code or services — purely additive (one script + one skill).
- The script's default endpoint matches the compose port mapping, so no `kubectl port-forward` is needed for the compose flow.

## Testing
- `bash -n` + `--dry-run` across full / minimal / delta modes; delta-mode arg validation; jq-less fallback emits valid JSON.
- `docker compose config` validates from the repo root for both prebuilt-overlay and build-local invocations; prebuilt overlay publishes the UI on `31323`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)